### PR TITLE
fix(runtime): throw when runtime module code generation fails in upda…

### DIFF
--- a/.changeset/013-runtime-module-update-hash-throw.md
+++ b/.changeset/013-runtime-module-update-hash-throw.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Throw when runtime module code generation fails in updateHash.

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -5440,24 +5440,32 @@ This prevents using hashes of each other and should be avoided.`);
 				chunkGraph.getChunkFullHashModulesIterable(chunk)
 			)) {
 				const moduleHash = createHash(hashFunction);
-				module.updateHash(moduleHash, {
-					chunkGraph,
-					runtime: chunk.runtime,
-					runtimeTemplate
-				});
-				const moduleHashDigest = moduleHash.digest(hashDigest);
-				const oldHash = chunkGraph.getModuleHash(module, chunk.runtime);
-				chunkGraph.setModuleHashes(
-					module,
-					chunk.runtime,
-					moduleHashDigest,
-					moduleHashDigest.slice(0, hashDigestLength)
-				);
-				/** @type {CodeGenerationJob} */
-				(
-					/** @type {Map<Module, CodeGenerationJob>} */
-					(codeGenerationJobsMap.get(oldHash)).get(module)
-				).hash = moduleHashDigest;
+				try {
+					module.updateHash(moduleHash, {
+						chunkGraph,
+						runtime: chunk.runtime,
+						runtimeTemplate
+					});
+					const moduleHashDigest = moduleHash.digest(hashDigest);
+					const oldHash = chunkGraph.getModuleHash(module, chunk.runtime);
+					chunkGraph.setModuleHashes(
+						module,
+						chunk.runtime,
+						moduleHashDigest,
+						moduleHashDigest.slice(0, hashDigestLength)
+					);
+					const jobs = codeGenerationJobsMap.get(oldHash);
+					if (jobs) {
+						const job = jobs.get(module);
+						if (job) {
+							job.hash = moduleHashDigest;
+						}
+					}
+				} catch (err) {
+					this.errors.push(
+						new (getModuleHashingError())(module, /** @type {Error} */ (err))
+					);
+				}
 			}
 			const chunkHash = createHash(hashFunction);
 			chunkHash.update(/** @type {string} */ (chunk.hash));

--- a/lib/RuntimeModule.js
+++ b/lib/RuntimeModule.js
@@ -136,18 +136,14 @@ class RuntimeModule extends Module {
 	updateHash(hash, context) {
 		hash.update(this.name);
 		hash.update(`${this.stage}`);
-		try {
-			const code =
-				this.fullHash || this.dependentHash
-					? // Do not use getGeneratedCode here, because i. e. compilation hash might be not
-						// ready at this point. We will cache it later instead.
-						this.generate()
-					: this.getGeneratedCode();
-			if (code !== null && code !== undefined) {
-				hash.update(code);
-			}
-		} catch (err) {
-			hash.update(/** @type {Error} */ (err).message);
+		const code =
+			this.fullHash || this.dependentHash
+				? // Do not use getGeneratedCode here, because i. e. compilation hash might be not
+					// ready at this point. We will cache it later instead.
+					this.generate()
+				: this.getGeneratedCode();
+		if (code !== null && code !== undefined) {
+			hash.update(code);
 		}
 		super.updateHash(hash, context);
 	}

--- a/test/RuntimeModule.unittest.js
+++ b/test/RuntimeModule.unittest.js
@@ -1,0 +1,103 @@
+"use strict";
+
+const RuntimeModule = require("../lib/RuntimeModule");
+const createHash = require("../lib/util/createHash");
+
+describe("RuntimeModule", () => {
+	class TestRuntimeModule extends RuntimeModule {
+		constructor(name, stage) {
+			super(name, stage);
+			this.code = "var test = 1;";
+		}
+
+		generate() {
+			return this.code;
+		}
+	}
+
+	it("should update hash with name, stage and generated code", () => {
+		const m = new TestRuntimeModule("test", 10);
+		const hash = createHash("md4");
+		m.updateHash(hash, {
+			chunkGraph: {
+				getModuleGraphHash: () => "graph-hash"
+			}
+		});
+
+		const expectedHash = createHash("md4");
+		expectedHash.update("test");
+		expectedHash.update("10");
+		expectedHash.update("var test = 1;");
+		expectedHash.update("graph-hash");
+
+		expect(hash.digest("hex")).toBe(expectedHash.digest("hex"));
+	});
+
+	it("should cache generated code during updateHash when not fullHash or dependentHash", () => {
+		const m = new TestRuntimeModule("test", 0);
+		expect(m._cachedGeneratedCode).toBeUndefined();
+
+		const hash = createHash("md4");
+		m.updateHash(hash, {
+			chunkGraph: {
+				getModuleGraphHash: () => ""
+			}
+		});
+
+		expect(m._cachedGeneratedCode).toBe("var test = 1;");
+		expect(m.getGeneratedCode()).toBe("var test = 1;");
+	});
+
+	it("should not cache generated code during updateHash when fullHash is true", () => {
+		const m = new TestRuntimeModule("test", 0);
+		m.fullHash = true;
+		expect(m._cachedGeneratedCode).toBeUndefined();
+
+		const hash = createHash("md4");
+		m.updateHash(hash, {
+			chunkGraph: {
+				getModuleGraphHash: () => ""
+			}
+		});
+
+		expect(m._cachedGeneratedCode).toBeUndefined();
+	});
+
+	it("should not cache generated code during updateHash when dependentHash is true", () => {
+		const m = new TestRuntimeModule("test", 0);
+		m.dependentHash = true;
+		expect(m._cachedGeneratedCode).toBeUndefined();
+
+		const hash = createHash("md4");
+		m.updateHash(hash, {
+			chunkGraph: {
+				getModuleGraphHash: () => ""
+			}
+		});
+
+		expect(m._cachedGeneratedCode).toBeUndefined();
+	});
+
+	it("should throw when generate() throws during updateHash instead of swallowing error", () => {
+		class ThrowingRuntimeModule extends RuntimeModule {
+			constructor() {
+				super("throwing");
+			}
+
+			generate() {
+				throw new Error("failed to generate code");
+			}
+		}
+
+		const m = new ThrowingRuntimeModule();
+		const hash = createHash("md4");
+
+		expect(() => {
+			m.updateHash(hash, {
+				chunkGraph: {
+					getModuleGraphHash: () => ""
+				}
+			});
+		}).toThrow("failed to generate code");
+	});
+});

--- a/test/configCases/runtime/runtime-module-update-hash-throw/errors.js
+++ b/test/configCases/runtime/runtime-module-update-hash-throw/errors.js
@@ -1,0 +1,6 @@
+"use strict";
+
+module.exports = [
+	[/error thrown in runtime module generate during hashing/],
+	[/error thrown in runtime module generate during hashing/]
+];

--- a/test/configCases/runtime/runtime-module-update-hash-throw/index.js
+++ b/test/configCases/runtime/runtime-module-update-hash-throw/index.js
@@ -1,0 +1,1 @@
+it("should fail compilation when runtime module throws during hashing", () => {});

--- a/test/configCases/runtime/runtime-module-update-hash-throw/webpack.config.js
+++ b/test/configCases/runtime/runtime-module-update-hash-throw/webpack.config.js
@@ -1,0 +1,33 @@
+"use strict";
+
+const { RuntimeModule } = require("../../../../");
+
+const PLUGIN_NAME = "RuntimeModuleUpdateHashThrowPlugin";
+
+class FailingRuntimeModule extends RuntimeModule {
+	constructor() {
+		super("failing runtime module");
+	}
+
+	generate() {
+		throw new Error("error thrown in runtime module generate during hashing");
+	}
+}
+
+/** @type {import("../../../../types").Configuration} */
+module.exports = {
+	plugins: [
+		{
+			apply(compiler) {
+				compiler.hooks.thisCompilation.tap(PLUGIN_NAME, (compilation) => {
+					compilation.hooks.additionalTreeRuntimeRequirements.tap(
+						PLUGIN_NAME,
+						(chunk) => {
+							compilation.addRuntimeModule(chunk, new FailingRuntimeModule());
+						}
+					);
+				});
+			}
+		}
+	]
+};


### PR DESCRIPTION
…teHash

Closes #22026

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Runtime module code-generation failures during hashing now surface as compilation errors instead of being silently absorbed.
  * Hash updates are handled safely when corresponding code-generation entries are unavailable.

* **Tests**
  * Added coverage for runtime module hashing, cached generated code, hash modes, and error propagation.
  * Added an integration test verifying compilation fails when runtime module generation throws.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->