### PR TITLE
fix(runtime): throw when runtime module code generation fails in updateHash

### DIFF
--- a/.changeset/013-runtime-module-update-hash-throw.md
+++ b/.changeset/013-runtime-module-update-hash-throw.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Throw when runtime module code generation fails in updateHash.

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -5440,24 +5440,32 @@ This prevents using hashes of each other and should be avoided.`);
 				chunkGraph.getChunkFullHashModulesIterable(chunk)
 			)) {
 				const moduleHash = createHash(hashFunction);
-				module.updateHash(moduleHash, {
-					chunkGraph,
-					runtime: chunk.runtime,
-					runtimeTemplate
-				});
-				const moduleHashDigest = moduleHash.digest(hashDigest);
-				const oldHash = chunkGraph.getModuleHash(module, chunk.runtime);
-				chunkGraph.setModuleHashes(
-					module,
-					chunk.runtime,
-					moduleHashDigest,
-					moduleHashDigest.slice(0, hashDigestLength)
-				);
-				/** @type {CodeGenerationJob} */
-				(
-					/** @type {Map<Module, CodeGenerationJob>} */
-					(codeGenerationJobsMap.get(oldHash)).get(module)
-				).hash = moduleHashDigest;
+				try {
+					module.updateHash(moduleHash, {
+						chunkGraph,
+						runtime: chunk.runtime,
+						runtimeTemplate
+					});
+					const moduleHashDigest = moduleHash.digest(hashDigest);
+					const oldHash = chunkGraph.getModuleHash(module, chunk.runtime);
+					chunkGraph.setModuleHashes(
+						module,
+						chunk.runtime,
+						moduleHashDigest,
+						moduleHashDigest.slice(0, hashDigestLength)
+					);
+					const jobs = codeGenerationJobsMap.get(oldHash);
+					if (jobs) {
+						const job = jobs.get(module);
+						if (job) {
+							job.hash = moduleHashDigest;
+						}
+					}
+				} catch (err) {
+					this.errors.push(
+						new (getModuleHashingError())(module, /** @type {Error} */ (err))
+					);
+				}
 			}
 			const chunkHash = createHash(hashFunction);
 			chunkHash.update(/** @type {string} */ (chunk.hash));

--- a/lib/RuntimeModule.js
+++ b/lib/RuntimeModule.js
@@ -136,18 +136,14 @@ class RuntimeModule extends Module {
 	updateHash(hash, context) {
 		hash.update(this.name);
 		hash.update(`${this.stage}`);
-		try {
-			const code =
-				this.fullHash || this.dependentHash
-					? // Do not use getGeneratedCode here, because i. e. compilation hash might be not
-						// ready at this point. We will cache it later instead.
-						this.generate()
-					: this.getGeneratedCode();
-			if (code !== null && code !== undefined) {
-				hash.update(code);
-			}
-		} catch (err) {
-			hash.update(/** @type {Error} */ (err).message);
+		const code =
+			this.fullHash || this.dependentHash
+				? // Do not use getGeneratedCode here, because i. e. compilation hash might be not
+					// ready at this point. We will cache it later instead.
+					this.generate()
+				: this.getGeneratedCode();
+		if (code !== null && code !== undefined) {
+			hash.update(code);
 		}
 		super.updateHash(hash, context);
 	}

--- a/test/RuntimeModule.unittest.js
+++ b/test/RuntimeModule.unittest.js
@@ -1,0 +1,103 @@
+"use strict";
+
+const RuntimeModule = require("../lib/RuntimeModule");
+const createHash = require("../lib/util/createHash");
+
+describe("RuntimeModule", () => {
+	class TestRuntimeModule extends RuntimeModule {
+		constructor(name, stage) {
+			super(name, stage);
+			this.code = "var test = 1;";
+		}
+
+		generate() {
+			return this.code;
+		}
+	}
+
+	it("should update hash with name, stage and generated code", () => {
+		const m = new TestRuntimeModule("test", 10);
+		const hash = createHash("md4");
+		m.updateHash(hash, {
+			chunkGraph: {
+				getModuleGraphHash: () => "graph-hash"
+			}
+		});
+
+		const expectedHash = createHash("md4");
+		expectedHash.update("test");
+		expectedHash.update("10");
+		expectedHash.update("var test = 1;");
+		expectedHash.update("graph-hash");
+
+		expect(hash.digest("hex")).toBe(expectedHash.digest("hex"));
+	});
+
+	it("should cache generated code during updateHash when not fullHash or dependentHash", () => {
+		const m = new TestRuntimeModule("test", 0);
+		expect(m._cachedGeneratedCode).toBeUndefined();
+
+		const hash = createHash("md4");
+		m.updateHash(hash, {
+			chunkGraph: {
+				getModuleGraphHash: () => ""
+			}
+		});
+
+		expect(m._cachedGeneratedCode).toBe("var test = 1;");
+		expect(m.getGeneratedCode()).toBe("var test = 1;");
+	});
+
+	it("should not cache generated code during updateHash when fullHash is true", () => {
+		const m = new TestRuntimeModule("test", 0);
+		m.fullHash = true;
+		expect(m._cachedGeneratedCode).toBeUndefined();
+
+		const hash = createHash("md4");
+		m.updateHash(hash, {
+			chunkGraph: {
+				getModuleGraphHash: () => ""
+			}
+		});
+
+		expect(m._cachedGeneratedCode).toBeUndefined();
+	});
+
+	it("should not cache generated code during updateHash when dependentHash is true", () => {
+		const m = new TestRuntimeModule("test", 0);
+		m.dependentHash = true;
+		expect(m._cachedGeneratedCode).toBeUndefined();
+
+		const hash = createHash("md4");
+		m.updateHash(hash, {
+			chunkGraph: {
+				getModuleGraphHash: () => ""
+			}
+		});
+
+		expect(m._cachedGeneratedCode).toBeUndefined();
+	});
+
+	it("should throw when generate() throws during updateHash instead of swallowing error", () => {
+		class ThrowingRuntimeModule extends RuntimeModule {
+			constructor() {
+				super("throwing");
+			}
+
+			generate() {
+				throw new Error("failed to generate code");
+			}
+		}
+
+		const m = new ThrowingRuntimeModule();
+		const hash = createHash("md4");
+
+		expect(() => {
+			m.updateHash(hash, {
+				chunkGraph: {
+					getModuleGraphHash: () => ""
+				}
+			});
+		}).toThrow("failed to generate code");
+	});
+});

--- a/test/configCases/runtime/runtime-module-update-hash-throw/errors.js
+++ b/test/configCases/runtime/runtime-module-update-hash-throw/errors.js
@@ -1,0 +1,6 @@
+"use strict";
+
+module.exports = [
+	[/error thrown in runtime module generate during hashing/],
+	[/error thrown in runtime module generate during hashing/]
+];

--- a/test/configCases/runtime/runtime-module-update-hash-throw/index.js
+++ b/test/configCases/runtime/runtime-module-update-hash-throw/index.js
@@ -1,0 +1,1 @@
+it("should fail compilation when runtime module throws during hashing", () => {});

--- a/test/configCases/runtime/runtime-module-update-hash-throw/webpack.config.js
+++ b/test/configCases/runtime/runtime-module-update-hash-throw/webpack.config.js
@@ -1,0 +1,33 @@
+"use strict";
+
+const { RuntimeModule } = require("../../../../");
+
+const PLUGIN_NAME = "RuntimeModuleUpdateHashThrowPlugin";
+
+class FailingRuntimeModule extends RuntimeModule {
+	constructor() {
+		super("failing runtime module");
+	}
+
+	generate() {
+		throw new Error("error thrown in runtime module generate during hashing");
+	}
+}
+
+/** @type {import("../../../../types").Configuration} */
+module.exports = {
+	plugins: [
+		{
+			apply(compiler) {
+				compiler.hooks.thisCompilation.tap(PLUGIN_NAME, (compilation) => {
+					compilation.hooks.additionalTreeRuntimeRequirements.tap(
+						PLUGIN_NAME,
+						(chunk) => {
+							compilation.addRuntimeModule(chunk, new FailingRuntimeModule());
+						}
+					);
+				});
+			}
+		}
+	]
+};


### PR DESCRIPTION
**Summary**

In `RuntimeModule.prototype.updateHash`, when `generate()` / `getGeneratedCode()` threw an error during module hashing, the error was caught and swallowed by hashing `err.message` instead:

```js
try {
  const code = this.fullHash || this.dependentHash ? this.generate() : this.getGeneratedCode();
  if (code !== null && code !== undefined) hash.update(code);
} catch (err) {
  hash.update(err.message);
}
```

Hashing `err.message` causes several issues:
1. It suppresses the underlying failure from `Compilation._createModuleHash`, preventing `ModuleHashingError` from being recorded and reported.
2. The hash of the module collapses to a constant error message string instead of reflecting the module's actual generated code.
3. Because the module hash serves as the cache key/etag in `Compilation/codeGeneration`, with persistent caching enabled (`cache: { type: "filesystem" }`), the cache saves and subsequent builds retrieve stale runtime module code across graph changes.

This PR removes the `try-catch` fallback to `err.message` in `RuntimeModule.updateHash`:
- If `generate()` throws during `_createModuleHash`, the error propagates to `Compilation._createModuleHash`, where it is caught and recorded as a `ModuleHashingError`, failing the build loudly instead of silently poisoning the persistent cache.
- In `Compilation.js`'s full-hash runtime modules pass, `module.updateHash` calls are wrapped to consistently record `ModuleHashingError` if generation fails.

Fixes #22026.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes:
- Added `test/RuntimeModule.unittest.js` to verify hashing with name, stage, and generated code, cache state handling with `fullHash`/`dependentHash`, and that errors thrown by `generate()` propagate rather than being swallowed into `err.message`.
- Added `test/configCases/runtime/runtime-module-update-hash-throw` asserting that a runtime module that throws during `generate()` properly fails compilation with `ModuleHashingError`.

**Does this PR introduce a breaking change?**

No. Runtime modules whose generation fails during hashing previously generated corrupted hashes and poisoned persistent cache entries.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

No.