### PR TITLE
fix(runtime): fail when a runtime module cannot be hashed

### DIFF
--- a/.changeset/013-runtime-module-hashing-failure.md
+++ b/.changeset/013-runtime-module-hashing-failure.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Fail the build when a runtime module's code generation throws while hashing.

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -5440,11 +5440,18 @@ This prevents using hashes of each other and should be avoided.`);
 				chunkGraph.getChunkFullHashModulesIterable(chunk)
 			)) {
 				const moduleHash = createHash(hashFunction);
-				module.updateHash(moduleHash, {
-					chunkGraph,
-					runtime: chunk.runtime,
-					runtimeTemplate
-				});
+				try {
+					module.updateHash(moduleHash, {
+						chunkGraph,
+						runtime: chunk.runtime,
+						runtimeTemplate
+					});
+				} catch (err) {
+					this.errors.push(
+						new (getModuleHashingError())(module, /** @type {Error} */ (err))
+					);
+					continue;
+				}
 				const moduleHashDigest = moduleHash.digest(hashDigest);
 				const oldHash = chunkGraph.getModuleHash(module, chunk.runtime);
 				chunkGraph.setModuleHashes(

--- a/lib/RuntimeModule.js
+++ b/lib/RuntimeModule.js
@@ -136,18 +136,16 @@ class RuntimeModule extends Module {
 	updateHash(hash, context) {
 		hash.update(this.name);
 		hash.update(`${this.stage}`);
-		try {
-			const code =
-				this.fullHash || this.dependentHash
-					? // Do not use getGeneratedCode here, because i. e. compilation hash might be not
-						// ready at this point. We will cache it later instead.
-						this.generate()
-					: this.getGeneratedCode();
-			if (code !== null && code !== undefined) {
-				hash.update(code);
-			}
-		} catch (err) {
-			hash.update(/** @type {Error} */ (err).message);
+		// A failing `generate()` propagates: hashing its message instead pins the etag
+		// of the code generation cache to a constant, which then serves stale code.
+		const code =
+			this.fullHash || this.dependentHash
+				? // Do not use getGeneratedCode here, because i. e. compilation hash might be not
+					// ready at this point. We will cache it later instead.
+					this.generate()
+				: this.getGeneratedCode();
+		if (code !== null && code !== undefined) {
+			hash.update(code);
 		}
 		super.updateHash(hash, context);
 	}

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -3342,7 +3342,7 @@ class RuntimeTemplate {
 	 * The `../` path from a chunk's own asset back to the output root. Hashes are
 	 * neutralized first: a runtime module is generated once to be hashed, before any
 	 * hash exists, so resolving one there throws — and `RuntimeModule.updateHash`
-	 * swallows that, pinning the module's hash to the message.
+	 * lets that throw fail the build rather than hashing it.
 	 * @param {Chunk} chunk the chunk whose asset holds the reference
 	 * @param {boolean} enforceRelative whether the answer keeps a leading `./`
 	 * @returns {string} the path back to the output root

--- a/test/configCases/errors/exception-in-chunk-renderer/__snapshots__/errors.snap
+++ b/test/configCases/errors/exception-in-chunk-renderer/__snapshots__/errors.snap
@@ -3,5 +3,7 @@
 exports[`errors 1`] = `
 Array [
   "Test exception",
+  "Test exception",
+  "Test exception",
 ]
 `;

--- a/test/configCases/runtime/hashing-error-full-hash/errors.js
+++ b/test/configCases/runtime/hashing-error-full-hash/errors.js
@@ -1,0 +1,6 @@
+"use strict";
+
+module.exports = [
+	[/generate of the throwing runtime module failed/],
+	[/generate of the throwing runtime module failed/]
+];

--- a/test/configCases/runtime/hashing-error-full-hash/index.js
+++ b/test/configCases/runtime/hashing-error-full-hash/index.js
@@ -1,0 +1,3 @@
+it("should report the failure of the re-render after hashing", () => {
+	expect(1).toBe(1);
+});

--- a/test/configCases/runtime/hashing-error-full-hash/webpack.config.js
+++ b/test/configCases/runtime/hashing-error-full-hash/webpack.config.js
@@ -1,0 +1,44 @@
+"use strict";
+
+const { RuntimeModule } = require("../../../../");
+
+const PLUGIN_NAME = "ThrowingFullHashRuntimeModulePlugin";
+
+class ThrowingFullHashRuntimeModule extends RuntimeModule {
+	constructor() {
+		super("throwing full hash", RuntimeModule.STAGE_TRIGGER);
+		this.fullHash = true;
+	}
+
+	/**
+	 * Generates runtime code for this runtime module.
+	 * @returns {string} runtime code
+	 */
+	generate() {
+		// The pre-hash pass has no full hash yet, so only the re-render after hashing
+		// throws — which is the call site this case covers.
+		if (!this.compilation || !this.compilation.fullHash) return "";
+		throw new Error("generate of the throwing runtime module failed");
+	}
+}
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	plugins: [
+		{
+			apply(compiler) {
+				compiler.hooks.thisCompilation.tap(PLUGIN_NAME, (compilation) => {
+					compilation.hooks.additionalTreeRuntimeRequirements.tap(
+						PLUGIN_NAME,
+						(chunk) => {
+							compilation.addRuntimeModule(
+								chunk,
+								new ThrowingFullHashRuntimeModule()
+							);
+						}
+					);
+				});
+			}
+		}
+	]
+};

--- a/test/configCases/runtime/hashing-error/errors.js
+++ b/test/configCases/runtime/hashing-error/errors.js
@@ -1,0 +1,6 @@
+"use strict";
+
+module.exports = [
+	[/generate of the throwing runtime module failed/],
+	[/generate of the throwing runtime module failed/]
+];

--- a/test/configCases/runtime/hashing-error/index.js
+++ b/test/configCases/runtime/hashing-error/index.js
@@ -1,0 +1,3 @@
+it("should report the failure instead of hashing its message", () => {
+	expect(1).toBe(1);
+});

--- a/test/configCases/runtime/hashing-error/webpack.config.js
+++ b/test/configCases/runtime/hashing-error/webpack.config.js
@@ -1,0 +1,37 @@
+"use strict";
+
+const { RuntimeModule } = require("../../../../");
+
+const PLUGIN_NAME = "ThrowingRuntimeModulePlugin";
+
+class ThrowingRuntimeModule extends RuntimeModule {
+	constructor() {
+		super("throwing");
+	}
+
+	/**
+	 * Generates runtime code for this runtime module.
+	 * @returns {string} runtime code
+	 */
+	generate() {
+		throw new Error("generate of the throwing runtime module failed");
+	}
+}
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	plugins: [
+		{
+			apply(compiler) {
+				compiler.hooks.thisCompilation.tap(PLUGIN_NAME, (compilation) => {
+					compilation.hooks.additionalTreeRuntimeRequirements.tap(
+						PLUGIN_NAME,
+						(chunk) => {
+							compilation.addRuntimeModule(chunk, new ThrowingRuntimeModule());
+						}
+					);
+				});
+			}
+		}
+	]
+};

--- a/types.d.ts
+++ b/types.d.ts
@@ -26513,7 +26513,7 @@ declare abstract class RuntimeTemplate {
 	 * The `../` path from a chunk's own asset back to the output root. Hashes are
 	 * neutralized first: a runtime module is generated once to be hashed, before any
 	 * hash exists, so resolving one there throws — and `RuntimeModule.updateHash`
-	 * swallows that, pinning the module's hash to the message.
+	 * lets that throw fail the build rather than hashing it.
 	 */
 	chunkRootOutputDir(chunk: Chunk, enforceRelative: boolean): string;
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

Closes #22026. `RuntimeModule.updateHash` hashed `err.message` when `generate()` threw, so the module's hash stopped depending on its code — the same constant on every build — while that hash is the etag of the `Compilation/codeGeneration` cache entry, so a warm filesystem cache served a stale runtime module. The throw now propagates into the `ModuleHashingError` that `_createModuleHash` already records for every other module type, and the previously unguarded re-hash of full-hash modules records it too instead of aborting the compilation.

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `test/configCases/runtime/hashing-error` (throwing `generate()`, covers `_createModuleHash`) and `test/configCases/runtime/hashing-error-full-hash` (a `fullHash` module that throws only on the re-render after hashing, covers the new `Compilation.js` catch). Both fail on the unmodified files. `test/configCases/errors/exception-in-chunk-renderer`'s snapshot gains two entries: its `requireExtensions` tap throws on every call, and the two hashing passes now report it instead of hiding it.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No, but a plugin whose runtime module `generate()` throws during hashing now fails the build instead of silently producing a content-independent hash.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

AI (Claude Code) was used to trace the cache-etag path from the issue report, write the patch and the two regression cases, and run the test and lint suites. Every change was reviewed and the tests were verified to fail without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018gPdrq1LXzGj1uJ7W5PNa9

---
_Generated by [Claude Code](https://claude.ai/code/session_018gPdrq1LXzGj1uJ7W5PNa9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Runtime module code-generation failures are now reported clearly and cause the build to fail, instead of being hidden by hashing the error message.
  - Errors encountered while processing full-hash modules are captured and reported without preventing other modules from being processed.
  - Improved consistency of error reporting during runtime module re-rendering after hashing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->