### PR TITLE
fix(css): fix @value replacement in keyframes and animation

### DIFF
--- a/.changeset/012-fix-css-value-keyframes.md
+++ b/.changeset/012-fix-css-value-keyframes.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Fix @value replacement in CSS Modules keyframes and animation names.

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -1680,6 +1680,11 @@ class CssParser extends Parser {
 						) {
 							continue;
 						}
+						// `@value` aliases are ICSS-rewritten; hashing here double-replaces.
+						if (icssDefinitions.size !== 0 && icssDefinitions.has(identifier)) {
+							found = true;
+							continue;
+						}
 						const { line: sl, column: sc } = locConverter.get(A.start(cv));
 						const { line: el, column: ec } = locConverter.get(A.end(cv));
 						recordDeclaration(identifier, kind, sl, sc);
@@ -3900,6 +3905,15 @@ class CssParser extends Parser {
 					isString ? start + 1 : start,
 					isString ? end - 1 : end
 				);
+				// `@value` aliases substitute as written; hashing them mangles animation names.
+				if (
+					!isString &&
+					icssDefinitions.size !== 0 &&
+					icssDefinitions.has(name)
+				) {
+					emitICSSSymbol(name, start, end);
+					return;
+				}
 				// Only grid-line names are declaration sites here; property-value references (`animation: foo`) are usages.
 				if (isGridProperty) recordDeclaration(name, "grid identifier", sl, sc);
 				addCssExport(

--- a/test/configCases/css/value-keyframes-animation/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/css/value-keyframes-animation/__snapshots__/ConfigCacheTest.snap
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigCacheTestCases css value-keyframes-animation exported tests should emit the stylesheet 1`] = `
+"/*!******************************!*\\\\
+  !*** css ./style.module.css ***!
+  \\\\******************************/
+
+
+._anim {
+	animation: pulseAnim 2s linear;
+}
+
+._named {
+	animation-name: pulseAnim;
+}
+
+@keyframes pulseAnim {
+	from {
+		opacity: 0;
+	}
+}
+
+@keyframes _localSpin {
+	from {
+		opacity: 1;
+	}
+}
+
+._spin {
+	animation: _localSpin 1s;
+}
+
+
+/*# sourceMappingURL=bundle0.css.map*/"
+`;

--- a/test/configCases/css/value-keyframes-animation/__snapshots__/ConfigTest.snap
+++ b/test/configCases/css/value-keyframes-animation/__snapshots__/ConfigTest.snap
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigTestCases css value-keyframes-animation exported tests should emit the stylesheet 1`] = `
+"/*!******************************!*\\\\
+  !*** css ./style.module.css ***!
+  \\\\******************************/
+
+
+._anim {
+	animation: pulseAnim 2s linear;
+}
+
+._named {
+	animation-name: pulseAnim;
+}
+
+@keyframes pulseAnim {
+	from {
+		opacity: 0;
+	}
+}
+
+@keyframes _localSpin {
+	from {
+		opacity: 1;
+	}
+}
+
+._spin {
+	animation: _localSpin 1s;
+}
+
+
+/*# sourceMappingURL=bundle0.css.map*/"
+`;

--- a/test/configCases/css/value-keyframes-animation/index.js
+++ b/test/configCases/css/value-keyframes-animation/index.js
@@ -1,0 +1,35 @@
+import * as styles from "./style.module.css";
+
+const fs = __non_webpack_require__("fs");
+const path = __non_webpack_require__("path");
+
+const css = () =>
+	fs.readFileSync(path.join(__dirname, "bundle0.css"), "utf-8");
+
+it("should export the @value name as the declared identifier", () => {
+	expect(styles.animName).toBe("pulseAnim");
+});
+
+it("should still scope the class that uses the animation", () => {
+	expect(styles.anim).toBe("_anim");
+	expect(styles.named).toBe("_named");
+});
+
+it("should substitute @value in animation and @keyframes without hashing", () => {
+	const source = css();
+	expect(source).toContain("animation: pulseAnim 2s linear");
+	expect(source).toContain("animation-name: pulseAnim");
+	expect(source).toContain("@keyframes pulseAnim");
+	expect(source).not.toContain("_pulseAnim");
+	expect(source).not.toContain("pulseAnimpulseAnim");
+});
+
+it("should still scope a keyframes name that is not an @value alias", () => {
+	expect(styles.localSpin).toBe("_localSpin");
+	expect(css()).toContain("@keyframes _localSpin");
+	expect(css()).toContain("animation: _localSpin 1s");
+});
+
+it("should emit the stylesheet", () => {
+	expect(css()).toMatchSnapshot();
+});

--- a/test/configCases/css/value-keyframes-animation/style.module.css
+++ b/test/configCases/css/value-keyframes-animation/style.module.css
@@ -1,0 +1,25 @@
+@value animName: pulseAnim;
+
+.anim {
+	animation: animName 2s linear;
+}
+
+.named {
+	animation-name: animName;
+}
+
+@keyframes animName {
+	from {
+		opacity: 0;
+	}
+}
+
+@keyframes localSpin {
+	from {
+		opacity: 1;
+	}
+}
+
+.spin {
+	animation: localSpin 1s;
+}

--- a/test/configCases/css/value-keyframes-animation/webpack.config.js
+++ b/test/configCases/css/value-keyframes-animation/webpack.config.js
@@ -1,0 +1,21 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	node: { __dirname: false, __filename: false },
+	mode: "development",
+	module: {
+		rules: [
+			{
+				test: /\.module\.css$/,
+				type: "css/module",
+				/** @type {import("../../../../").GeneratorOptionsByModuleTypeKnown["css/module"]} */
+				generator: { localIdentName: "_[local]" }
+			}
+		]
+	},
+	experiments: {
+		css: true
+	}
+};


### PR DESCRIPTION
**Summary**

Fixes #22030 by correcting CSS Modules `@value` substitution for `animation` and `@keyframes` names so they resolve to the declared value instead of a hashed/mangled name.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes — added a configCases regression covering `@value` in `animation` and `@keyframes`.

**Does this PR introduce a breaking change?**

No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

Yes. A Cursor cloud coding agent investigated the CSS Modules `@value` / keyframes path, implemented the fix and regression test, and drafted this PR. A human (Yahiro025) owns the contribution and CLA identity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CSS Modules handling of `@value` aliases used in animation declarations and keyframes.
  * Aliased animation names now remain correctly referenced, while unrelated local class and keyframe names continue to be scoped as expected.

* **Tests**
  * Added coverage for `animation`, `animation-name`, and `@keyframes` usage with CSS Modules `@value` aliases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->