### PR TITLE
fix(html): reset the dropped-duplicate flag at every tag boundary

### DIFF
--- a/lib/html/syntax.js
+++ b/lib/html/syntax.js
@@ -8619,6 +8619,7 @@ const handleStartTagToken = (
 	if (eofInTag) {
 		// Any attribute slots already allocated for it are orphaned.
 		pendAttrStart = 0;
+		pendAttrDropped = false;
 		return end;
 	}
 	const name = internLowerName(TAG_NAME_INTERN, input, nameStart, nameEnd);
@@ -8640,6 +8641,7 @@ const handleStartTagToken = (
 		}
 	}
 	pendAttrStart = 0;
+	pendAttrDropped = false;
 	tok.selfClosing = selfClosing;
 	tok.swallowNewline = false;
 	tok.pos.start = start;
@@ -8669,6 +8671,7 @@ const handleEndTagToken = (input, start, end, nameStart, nameEnd) => {
 	}
 	// End tags drop any parsed attributes (the slots are orphaned).
 	pendAttrStart = 0;
+	pendAttrDropped = false;
 	tok.type = TOKEN_END_TAG;
 	tok.name = name;
 	tok.pos.start = start;
@@ -8754,6 +8757,7 @@ const parseHtml = (input, pos = 0, options = {}) => {
 	form = 0;
 	framesetOk = true;
 	pendAttrStart = 0;
+	pendAttrDropped = false;
 	fosterParenting = false;
 	_fosteredLog = null;
 	_printFromSource = false;

--- a/test/HtmlSyntax.unittest.js
+++ b/test/HtmlSyntax.unittest.js
@@ -10247,3 +10247,47 @@ describe("SourceProcessor — reflected attributes are read per element", () => 
 		expect(minify('<div vspace="008">x</div>')).toBe("<div vspace=008>x</div>");
 	});
 });
+
+describe("SourceProcessor — the dropped-duplicate flag is per tag", () => {
+	const { SourceProcessor } = require("../lib/html/syntax");
+
+	/**
+	 * @param {string} html input markup
+	 * @returns {string} the minified serialization
+	 */
+	const minify = (html) =>
+		new SourceProcessor().process(html, { mode: "minify" }).code;
+
+	/**
+	 * Markup allocating more attributes than the columns are kept at, so the
+	 * release after it drops the name column instead of clearing it.
+	 * @returns {string} the markup
+	 */
+	const oversizedDocument = () => {
+		let src = "";
+		for (let i = 0; i < 660; i++) {
+			src += "<i";
+			for (let j = 0; j < 100; j++) src += ` data-${i}-${j}="1"`;
+			src += "></i>";
+		}
+		return src;
+	};
+
+	it("clears it on a start tag that dropped one", () => {
+		const src = `${oversizedDocument()}<b class="c" class="d"></b>`;
+		expect(minify(src)).toContain("<b class=c></b>");
+		expect(minify("<br>")).toBe("<br>");
+	});
+
+	it("clears it on an end tag, which drops every attribute it parsed", () => {
+		const src = `${oversizedDocument()}</b class="c" class="d">`;
+		expect(minify(src)).toContain("data-659-99=1></i>");
+		expect(minify("<br>")).toBe("<br>");
+	});
+
+	it("clears it on a start tag the tokenizer only emitted at EOF", () => {
+		const src = `${oversizedDocument()}<b class="c" class="d"`;
+		expect(minify(src)).toContain("data-659-99=1></i>");
+		expect(minify("<br>")).toBe("<br>");
+	});
+});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

`pendAttrDropped` is cleared only where an attribute run opens, so a tag carrying no attributes reads the previous tag's flag and scans the attribute table from index 0. Past the column shrink threshold the released name column is dropped entirely, so the next parse throws `TypeError: Cannot read properties of undefined (reading 'length')`. This supersedes #22021 (same four-line fix, with a regression test that actually reproduces the crash and CodeRabbit's quote-style finding addressed).

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes — `test/HtmlSyntax.unittest.js`, three cases covering the start-tag, end-tag and eof-in-tag resets; each fails on `main` with the TypeError above and passes with the fix.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

Written with Claude Code: it reproduced the crash from #22021's claim, verified the four resets against `lib/html/syntax.js`, and wrote the regression cases. No changeset is added — `pendAttrDropped` arrived unreleased in #22018, whose pending `.changeset/016-html-keep-repeated-token.md` this folds into, so the crash never shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PHi3c4rfUQjoUb9XkCQRZZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHi3c4rfUQjoUb9XkCQRZZ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed HTML processing in cases involving duplicate attributes across consecutive tags.
  - Prevented malformed or unexpected output when tags are incomplete at end-of-file.
  - Ensured separate HTML parses no longer inherit stale attribute-processing state.
- **Tests**
  - Added coverage for duplicate attributes, end tags, incomplete tags, and subsequent parsing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->