### PR TITLE
test(css): hold a painted color to the tokens around it

### DIFF
--- a/test/helpers/syntaxEquivalence.js
+++ b/test/helpers/syntaxEquivalence.js
@@ -190,6 +190,10 @@ const installHelpers = () => {
 	// One word, so a number with its unit is read whole rather than as an ident.
 	const WORD_RE = /[\w-]/;
 
+	// CSS Syntax §4.2: a name code point is also anything non-ASCII, which the
+	// token after a color can start with.
+	const NAME_RE = /[\w-]|[\u0080-\uFFFF]/;
+
 	/**
 	 * Every color a value holds, as the pixel it paints. A color the engine hands
 	 * back as written — a `var()` fallback, the one `image()` carries — is a color
@@ -211,7 +215,16 @@ const installHelpers = () => {
 						: word;
 				word = "";
 			};
-			for (const ch of run.replace(COLOR_TOKEN_RE, (color) => painted(color))) {
+			// A pixel ends in a channel, so `rgba(…)0` — the form the printer writes,
+			// since the `)` parts them — would read as one channel more.
+			const painting = run.replace(
+				COLOR_TOKEN_RE,
+				(color, at, whole) =>
+					`${painted(color)}${
+						NAME_RE.test(whole[at + color.length] || "") ? " " : ""
+					}`
+			);
+			for (const ch of painting) {
 				if (WORD_RE.test(ch)) {
 					word += ch;
 					continue;
@@ -513,7 +526,13 @@ const installHelpers = () => {
 				written || lost
 					? normalizeValue(specified)
 					: style.getPropertyValue(property);
-			out.push(`${property}${bang}:${painted(canonical(resolved))}`);
+			// A value that is not itself a color still carries them: `box-shadow`
+			// keeps the space its color was written in, so each one is painted.
+			const named = canonical(resolved);
+			const whole = painted(named);
+			out.push(
+				`${property}${bang}:${whole === named ? paintedColors(named) : whole}`
+			);
 		}
 		return out;
 	};

--- a/test/syntaxEquivalence.spectest.js
+++ b/test/syntaxEquivalence.spectest.js
@@ -493,17 +493,14 @@ describe("printer output in real Chrome", () => {
 			filed.has(each.name) ? each.name : `${each.name}: ${each.why}`
 		);
 
-	const describeCorpus = (at, label) => {
-		describe(label, () => {
-			if (at === 1 && !hasCorpus()) {
-				it(NO_CORPUS, () => {
-					// No-op: the corpus is an optional git submodule.
-				});
+	/**
+	 * @param {number} at which of the built corpora to describe
+	 * @returns {void}
+	 */
+	const describeCorpus = (at) => {
+		const one = corpora[at];
 
-				return;
-			}
-			const one = corpora[at];
-
+		describe(one.label, () => {
 			// One test per page, not per corpus: the file is what a defect is filed
 			// against, so a failure names it without anything having to narrow it
 			// down. Every part of the document the engine builds — the element tree,
@@ -695,8 +692,16 @@ describe("printer output in real Chrome", () => {
 		});
 	};
 
-	describeCorpus(0, "configCases");
-	describeCorpus(1, "wpt");
+	// Which corpora were built depends on what is checked out, so each names
+	// itself, and one that could not be built says so rather than going quiet.
+	for (const at of corpora.keys()) describeCorpus(at);
+	if (!corpora.some((one) => one.label === "wpt")) {
+		describe("wpt", () => {
+			it(NO_CORPUS, () => {
+				// No-op: the corpus is an optional git submodule.
+			});
+		});
+	}
 
 	// One test per declaration, not per file: the value is what a defect is filed
 	// against, so the run names it without anything having to narrow it down.

--- a/test/syntaxEquivalence.spectest.js
+++ b/test/syntaxEquivalence.spectest.js
@@ -612,6 +612,45 @@ describe("printer output in real Chrome", () => {
 				FILE_TIMEOUT
 			);
 
+			// A pixel ends in a channel, so the pixel a color paints has to be parted
+			// from a name code point after it, which the `)` it replaced parted.
+			it(
+				"parts a painted color from the token written against it",
+				async () => {
+					const differences = await compareStylesheets([
+						{
+							name: "color-then-name-token",
+							raw: ".a{--s:oklch(0% 0 0) calc(1px)}",
+							min: ".a{--s:oklch(0% 0 0)calc(1px)}"
+						},
+						{
+							name: "color-then-non-ascii-name",
+							raw: ".a{--s:oklch(0% 0 0) \u00E9}",
+							min: ".a{--s:oklch(0% 0 0)\u00E9}"
+						}
+					]);
+					expect(differences).toEqual([]);
+				},
+				FILE_TIMEOUT
+			);
+
+			// A value that is not itself a color still carries them, and the computed
+			// value keeps the space each was written in.
+			it(
+				"paints the colors a computed value carries",
+				async () => {
+					const differences = await compareStylesheets([
+						{
+							name: "shadow-color-space",
+							raw: ".a{box-shadow:0 1px oklch(0% 0 0/.01) inset,0 -1px oklch(100% 0 0/.01) inset}",
+							min: ".a{box-shadow:0 1px#00000003 inset,0 -1px#ffffff03 inset}"
+						}
+					]);
+					expect(differences).toEqual([]);
+				},
+				FILE_TIMEOUT
+			);
+
 			// `/*` inside an unquoted `url()` is the address, so a fixture whose url
 			// spells one out is naming no option.
 			it("reads no cssom note out of a url() body", () => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Two defects in the CSS equivalence comparison, each of which reports a correctly-printed stylesheet as a divergence. The pixel a color paints ends in a channel, so a name code point written straight against it — `oklch(0% 0 0)calc(…)`, the form the printer writes since the `)` already parts them — read as one channel more. And `computed()` painted only a value that is itself a color, so `box-shadow` kept the space its color was written in and two spellings of one color compared unequal. Refs #21949.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

test

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — two cases in `test/syntaxEquivalence.spectest.js`, one per defect, each covering both branches; every `min` side is what the printer actually writes. Both fail on `main` and pass here.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No — `test/` only, no `lib/` change.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Yes — used to diagnose both defects and verify the fixes. Each was reproduced against the framework stylesheets #21949 installs: on `main`, Primer 21 and Tailwind 4 + daisyUI 5 diverge, and the other 23 do not; with this change all 25 pass. The reorder divergences #21949 filed against Semantic UI 2, Beer CSS 5 and Tabler 1 no longer reproduce on current `main`, so nothing is filed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DJb8PH8j4EKseWYCx8mXsy

---
_Generated by [Claude Code](https://claude.ai/code/session_01DJb8PH8j4EKseWYCx8mXsy)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded syntax-equivalence coverage for color tokens followed by adjacent name characters.
  * Added regression tests for colors embedded in shadow values.
  * Improved corpus test generation and reporting when Web Platform Test corpora are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->