### PR TITLE
refactor: reuse _createModuleHash for full-hash re-hash pass

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -5417,14 +5417,6 @@ This prevents using hashes of each other and should be avoided.`);
 		for (const chunk of initialChunks) processChunk(chunk);
 		for (const chunk of runtimeChunks) processChunk(chunk);
 		for (const chunk of entryChunks) processChunk(chunk);
-		if (errors.length > 0) {
-			errors.sort(
-				compareSelect((err) => err.module, compareModulesByIdentifier)
-			);
-			for (const error of errors) {
-				this.errors.push(error);
-			}
-		}
 
 		this.logger.timeAggregateEnd("hashing: hash runtime modules");
 		this.logger.timeAggregateEnd("hashing: hash chunks");
@@ -5439,26 +5431,16 @@ This prevents using hashes of each other and should be avoided.`);
 			for (const module of /** @type {Iterable<RuntimeModule>} */ (
 				chunkGraph.getChunkFullHashModulesIterable(chunk)
 			)) {
-				const moduleHash = createHash(hashFunction);
-				try {
-					module.updateHash(moduleHash, {
-						chunkGraph,
-						runtime: chunk.runtime,
-						runtimeTemplate
-					});
-				} catch (err) {
-					this.errors.push(
-						new (getModuleHashingError())(module, /** @type {Error} */ (err))
-					);
-					continue;
-				}
-				const moduleHashDigest = moduleHash.digest(hashDigest);
 				const oldHash = chunkGraph.getModuleHash(module, chunk.runtime);
-				chunkGraph.setModuleHashes(
+				const moduleHashDigest = this._createModuleHash(
 					module,
+					chunkGraph,
 					chunk.runtime,
-					moduleHashDigest,
-					moduleHashDigest.slice(0, hashDigestLength)
+					hashFunction,
+					runtimeTemplate,
+					hashDigest,
+					hashDigestLength,
+					errors
 				);
 				/** @type {CodeGenerationJob} */
 				(
@@ -5475,6 +5457,16 @@ This prevents using hashes of each other and should be avoided.`);
 			this.hooks.contentHash.call(chunk);
 		}
 		this.logger.timeEnd("hashing: process full hash modules");
+
+		if (errors.length > 0) {
+			errors.sort(
+				compareSelect((err) => err.module, compareModulesByIdentifier)
+			);
+			for (const error of errors) {
+				this.errors.push(error);
+			}
+		}
+
 		return codeGenerationJobs;
 	}
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Follow-up to #22034. Refs #22026.

Reusing `_createModuleHash` gives both passes one implementation and one failure behavior. And now second-pass throw the same `ModuleHashingError` and the same `XXXXXX` hash the first pass already uses. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->



**What kind of change does this PR introduce?**

refactor
<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

Existing
<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a
<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

No
<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved hashing reliability for full-hash modules.
  - Hashing errors are now collected and reported after processing completes.
  - Failed module hashes receive a fallback digest to ensure consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->