### PR TITLE
fix(css): keep css module exports for a direct importModule() call

### DIFF
--- a/.changeset/017-css-modules-loader-import-module.md
+++ b/.changeset/017-css-modules-loader-import-module.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Keep CSS module exports for a direct loader `importModule()` call.

--- a/lib/css/CssGenerator.js
+++ b/lib/css/CssGenerator.js
@@ -32,6 +32,7 @@ const Template = require("../Template");
 const { getPresentKinds } = require("../TemplatedPathPlugin");
 const CssImportDependency = require("../dependencies/CssImportDependency");
 const HarmonyImportSideEffectDependency = require("../dependencies/HarmonyImportSideEffectDependency");
+const LoaderImportDependency = require("../dependencies/LoaderImportDependency");
 
 const { encodeMappings } = require("../util/createMappings");
 const {
@@ -665,6 +666,13 @@ class CssGenerator extends Generator {
 					connection.dependency.category === "html-style-attribute")
 			) {
 				hasCssText = true;
+				continue;
+			}
+
+			// `importModule()` executes the module as JavaScript, and its dependency
+			// carries no origin module (`connectOrigin: false` in `LoaderPlugin`).
+			if (connection.dependency instanceof LoaderImportDependency) {
+				hasJs = true;
 				continue;
 			}
 

--- a/test/configCases/css/import-module-css-modules/classes.js
+++ b/test/configCases/css/import-module-css-modules/classes.js
@@ -1,0 +1,1 @@
+// Replaced by `loader.js` with the exports of the imported CSS modules.

--- a/test/configCases/css/import-module-css-modules/index.js
+++ b/test/configCases/css/import-module-css-modules/index.js
@@ -1,0 +1,8 @@
+import classes from "./classes.js";
+
+it("should keep CSS module exports for a direct importModule() call", () => {
+	for (const request of Object.keys(classes)) {
+		expect(classes[request]).toEqual({ button: "button", title: "title" });
+	}
+	expect(Object.keys(classes)).toHaveLength(4);
+});

--- a/test/configCases/css/import-module-css-modules/loader.js
+++ b/test/configCases/css/import-module-css-modules/loader.js
@@ -1,0 +1,16 @@
+/** @type {import("../../../../").LoaderDefinitionFunction} */
+module.exports = async function () {
+	const requests = [
+		"./style.module.css",
+		"./style.module.css?exportsOnly",
+		"./style.css?module",
+		"./style.css?module&exportsOnly"
+	];
+	/** @type {Record<string, EXPECTED_ANY>} */
+	const result = {};
+	for (const request of requests) {
+		const exports = await this.importModule(request);
+		result[request] = { button: exports.button, title: exports.title };
+	}
+	return `module.exports = ${JSON.stringify(result)};`;
+};

--- a/test/configCases/css/import-module-css-modules/style.css
+++ b/test/configCases/css/import-module-css-modules/style.css
@@ -1,0 +1,7 @@
+.button {
+	color: red;
+}
+
+.title {
+	color: green;
+}

--- a/test/configCases/css/import-module-css-modules/style.module.css
+++ b/test/configCases/css/import-module-css-modules/style.module.css
@@ -1,0 +1,7 @@
+.button {
+	color: red;
+}
+
+.title {
+	color: green;
+}

--- a/test/configCases/css/import-module-css-modules/webpack.config.js
+++ b/test/configCases/css/import-module-css-modules/webpack.config.js
@@ -1,0 +1,38 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	mode: "development",
+	module: {
+		generator: {
+			"css/auto": {
+				localIdentName: "[local]"
+			},
+			"css/module": {
+				localIdentName: "[local]"
+			}
+		},
+		rules: [
+			{
+				test: /classes\.js$/,
+				use: "./loader"
+			},
+			{
+				test: /\.css$/,
+				resourceQuery: /module/,
+				type: "css/module"
+			},
+			{
+				test: /\.css$/,
+				resourceQuery: /exportsOnly/,
+				generator: {
+					exportsOnly: true
+				}
+			}
+		]
+	},
+	experiments: {
+		css: true
+	}
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Fixes #22046. `importModule()` creates a `LoaderImportDependency` with `connectOrigin: false`, so `CssGenerator.getTypes()` skipped that connection as having no origin module and gave the CSS module no JavaScript output — a loader importing a CSS module directly received `{}` instead of the class-name mapping. Recognizing the loader import keeps the existing optimization for genuinely CSS-only connections, so CSS modules reached only through `@import`/`composes`/`@value` still get no JavaScript factory.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `test/configCases/css/import-module-css-modules/` covers `css/auto` and `css/module` with `exportsOnly` both off and on, and runs under `ConfigCacheTestCases` too.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Yes — Claude Code was used to investigate the issue, write the regression case and implement the fix. Everything was reviewed and verified locally: the new case in both `ConfigTestCases` and `ConfigCacheTestCases`, all `css` config cases, the `loader-import-module` cases, and full `yarn lint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DR6wdzkBvcqTm4pwdHJT7W

---
_Generated by [Claude Code](https://claude.ai/code/session_01DR6wdzkBvcqTm4pwdHJT7W)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved CSS Module exports when CSS is imported directly through loader APIs.
  * Ensured CSS Module class mappings remain available across standard, module, and exports-only import variations.

* **Tests**
  * Added coverage for CSS Module exports, including class names and multiple import configurations.

* **Documentation**
  * Added a changeset documenting the CSS Module export preservation fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->