### PR TITLE
fix: hash inlined export literals at the dependency level

### DIFF
--- a/lib/ChunkGraph.js
+++ b/lib/ChunkGraph.js
@@ -9,7 +9,6 @@ const util = require("util");
 const Entrypoint = require("./Entrypoint");
 const ModuleGraphConnection = require("./ModuleGraphConnection");
 const { DEFAULTS } = require("./config/defaults");
-const { isExportInlined } = require("./optimize/InlineExports");
 const { first } = require("./util/SetHelpers");
 const SortableSet = require("./util/SortableSet");
 const {
@@ -22,7 +21,6 @@ const {
 } = require("./util/comparators");
 const createHash = require("./util/createHash");
 const findGraphRoots = require("./util/findGraphRoots");
-const memoize = require("./util/memoize");
 const {
 	RuntimeSpecMap,
 	RuntimeSpecSet,
@@ -30,10 +28,6 @@ const {
 	mergeRuntime,
 	runtimeToString
 } = require("./util/runtime");
-
-const getHarmonyImportSpecifierDependency = memoize(() =>
-	require("./dependencies/HarmonyImportSpecifierDependency")
-);
 
 /** @import AsyncDependenciesBlock from "./AsyncDependenciesBlock" */
 /** @import Chunk, { Chunks, Entrypoints, ChunkId } from "./Chunk" */
@@ -73,23 +67,6 @@ const activeStateToString = (state) => {
 	if (state === true) return "T";
 	if (state === ModuleGraphConnection.TRANSITIVE_ONLY) return "O";
 	throw new Error("Not implemented active state");
-};
-
-/**
- * True when an inactive connection still embeds an inlined export literal
- * in the referencing module's generated code (must stay in its hash).
- * @param {ModuleGraph} moduleGraph module graph
- * @param {ModuleGraphConnection} connection connection
- * @param {RuntimeSpec} runtime runtime
- * @returns {boolean} true when the connection contributes an inlined literal
- */
-const connectionInactiveDueToInlining = (moduleGraph, connection, runtime) => {
-	const module = connection.module;
-	if (!module) return false;
-	const dep = connection.dependency;
-	// Lazy: top-level require cycles Module → ChunkGraph → dependency → Module.
-	if (!(dep instanceof getHarmonyImportSpecifierDependency())) return false;
-	return isExportInlined(moduleGraph, module, dep.getIds(moduleGraph), runtime);
 };
 
 const compareModuleIterables = compareIterables(compareModulesByIdentifier);
@@ -1908,20 +1885,7 @@ Caller might not support runtime-dependent code generation (opt-out via optimiza
 			if (runtime === undefined || typeof runtime === "string") {
 				for (const connection of connections) {
 					const state = connection.getActiveState(runtime);
-					if (state === false) {
-						// Keep inlined imports in the hash: their literals are
-						// embedded in this module's codegen (#22019).
-						if (
-							connectionInactiveDueToInlining(
-								this.moduleGraph,
-								connection,
-								runtime
-							)
-						) {
-							processConnection(connection, "I");
-						}
-						continue;
-					}
+					if (state === false) continue;
 					processConnection(connection, state === true ? "T" : "O");
 				}
 			} else {
@@ -1941,18 +1905,7 @@ Caller might not support runtime-dependent code generation (opt-out via optimiza
 					);
 					if (states.size === 1) {
 						const state = first(states);
-						if (state === false) {
-							if (
-								connectionInactiveDueToInlining(
-									this.moduleGraph,
-									connection,
-									runtime
-								)
-							) {
-								processConnection(connection, "I");
-							}
-							continue;
-						}
+						if (state === false) continue;
 						stateInfo = activeStateToString(
 							/** @type {ConnectionState} */
 							(state)

--- a/lib/FlagDependencyExportsPlugin.js
+++ b/lib/FlagDependencyExportsPlugin.js
@@ -30,40 +30,15 @@ const PLUGIN_LOGGER_NAME = `webpack.${PLUGIN_NAME}`;
 /** @typedef {{ etag: string, data: InstanceType<RestoreProvidedData> }} MemCacheEntry */
 
 /**
- * Cache key fragment for what changes provided exports without changing the
- * module's source: still-lazy barrel requests and DefinePlugin value versions.
  * @param {Module} module the module
  * @param {LazyBarrelController} lazyBarrelController the compilation's lazy barrel controller
  * @param {HashFunction} hashFunction hash function for long keys
- * @returns {string} etag for provided-exports mem/persistent cache, "" when neither applies
+ * @returns {string} the hash
  */
-const getProvidedExportsEtag = (module, lazyBarrelController, hashFunction) => {
-	const lazyRequests = lazyBarrelController.getLazyRequests(module);
-	const buildInfo = /** @type {BuildInfo | undefined} */ (module.buildInfo);
-	const valueDependencies = buildInfo && buildInfo.valueDependencies;
-	const hasValueDependencies =
-		valueDependencies !== undefined && valueDependencies.size > 0;
-	if (!lazyRequests && !hasValueDependencies) return "";
-	/** @type {(string | string[] | undefined)[][]} */
-	const valueEntries = [];
-	if (hasValueDependencies) {
-		const versions =
-			/** @type {NonNullable<BuildInfo["valueDependencies"]>} */
-			(valueDependencies);
-		for (const key of [...versions.keys()].sort()) {
-			const value = versions.get(key);
-			// An absent version serializes as null, distinct from both other shapes
-			valueEntries.push([
-				key,
-				value instanceof Set ? [...value].sort() : value
-			]);
-		}
-	}
-	// JSON, so a separator inside a request or a version cannot forge another entry
-	const joined = JSON.stringify([
-		lazyRequests ? [...lazyRequests] : [],
-		valueEntries
-	]);
+const getLazyRequestsHash = (module, lazyBarrelController, hashFunction) => {
+	const lazyKeys = lazyBarrelController.getLazyRequests(module);
+	if (!lazyKeys) return "";
+	const joined = [...lazyKeys].join("|");
 	if (joined.length < 100) return joined;
 	const hash = createHash(hashFunction);
 	hash.update(joined);
@@ -132,7 +107,7 @@ class FlagDependencyExportsPlugin {
 							const memCache = moduleMemCaches && moduleMemCaches.get(module);
 							/** @type {MemCacheEntry | undefined} */
 							const memCacheEntry = memCache && memCache.get(this);
-							const etag = getProvidedExportsEtag(
+							const hash = getLazyRequestsHash(
 								module,
 								lazyBarrelController,
 								hashFunction
@@ -141,7 +116,7 @@ class FlagDependencyExportsPlugin {
 							// detection cannot invalidate the mem cache when the un-lazied
 							// connections are unsafe-cached (they are skipped when comparing
 							// references)
-							if (memCacheEntry !== undefined && memCacheEntry.etag === etag) {
+							if (memCacheEntry !== undefined && memCacheEntry.etag === hash) {
 								statRestoredFromMemCache++;
 								exportsInfo.restoreProvided(memCacheEntry.data);
 								return callback();
@@ -151,7 +126,7 @@ class FlagDependencyExportsPlugin {
 							);
 							cache.get(
 								module.identifier(),
-								etag ? `${buildHash}|${etag}` : buildHash,
+								hash ? `${buildHash}|${hash}` : buildHash,
 								(err, result) => {
 									if (err) return callback(err);
 
@@ -374,13 +349,12 @@ class FlagDependencyExportsPlugin {
 												changed = true;
 											}
 
-											if (inlined !== undefined) {
-												const prev = exportInfo.canInlineProvide;
-												// Watch rebuilds keep ExportInfo; refresh when the constant changes
-												if (prev === undefined || !prev.equals(inlined)) {
-													exportInfo.canInlineProvide = inlined;
-													changed = true;
-												}
+											if (
+												inlined !== undefined &&
+												exportInfo.canInlineProvide === undefined
+											) {
+												exportInfo.canInlineProvide = inlined;
+												changed = true;
 											}
 
 											if (terminalBinding && !exportInfo.terminalBinding) {
@@ -537,7 +511,7 @@ class FlagDependencyExportsPlugin {
 										.getRestoreProvidedData();
 									const memCache =
 										moduleMemCaches && moduleMemCaches.get(module);
-									const etag = getProvidedExportsEtag(
+									const hash = getLazyRequestsHash(
 										module,
 										lazyBarrelController,
 										hashFunction
@@ -545,7 +519,7 @@ class FlagDependencyExportsPlugin {
 									if (memCache) {
 										/** @type {MemCacheEntry} */
 										const entry = {
-											etag,
+											etag: hash,
 											data: cachedData
 										};
 										memCache.set(this, entry);
@@ -555,7 +529,7 @@ class FlagDependencyExportsPlugin {
 									);
 									cache.store(
 										module.identifier(),
-										etag ? `${buildHash}|${etag}` : buildHash,
+										hash ? `${buildHash}|${hash}` : buildHash,
 										cachedData,
 										callback
 									);

--- a/lib/FlagDependencyExportsPlugin.js
+++ b/lib/FlagDependencyExportsPlugin.js
@@ -349,12 +349,12 @@ class FlagDependencyExportsPlugin {
 												changed = true;
 											}
 
-											if (
-												inlined !== undefined &&
-												exportInfo.canInlineProvide === undefined
-											) {
-												exportInfo.canInlineProvide = inlined;
-												changed = true;
+											if (inlined !== undefined) {
+												const prev = exportInfo.canInlineProvide;
+												if (prev === undefined || !prev.equals(inlined)) {
+													exportInfo.canInlineProvide = inlined;
+													changed = true;
+												}
 											}
 
 											if (terminalBinding && !exportInfo.terminalBinding) {

--- a/lib/FlagDependencyExportsPlugin.js
+++ b/lib/FlagDependencyExportsPlugin.js
@@ -30,15 +30,40 @@ const PLUGIN_LOGGER_NAME = `webpack.${PLUGIN_NAME}`;
 /** @typedef {{ etag: string, data: InstanceType<RestoreProvidedData> }} MemCacheEntry */
 
 /**
+ * Cache key fragment for what changes provided exports without changing the
+ * module's source: still-lazy barrel requests and DefinePlugin value versions.
  * @param {Module} module the module
  * @param {LazyBarrelController} lazyBarrelController the compilation's lazy barrel controller
  * @param {HashFunction} hashFunction hash function for long keys
- * @returns {string} the hash
+ * @returns {string} etag for provided-exports mem/persistent cache, "" when neither applies
  */
-const getLazyRequestsHash = (module, lazyBarrelController, hashFunction) => {
-	const lazyKeys = lazyBarrelController.getLazyRequests(module);
-	if (!lazyKeys) return "";
-	const joined = [...lazyKeys].join("|");
+const getProvidedExportsEtag = (module, lazyBarrelController, hashFunction) => {
+	const lazyRequests = lazyBarrelController.getLazyRequests(module);
+	const buildInfo = /** @type {BuildInfo | undefined} */ (module.buildInfo);
+	const valueDependencies = buildInfo && buildInfo.valueDependencies;
+	const hasValueDependencies =
+		valueDependencies !== undefined && valueDependencies.size > 0;
+	if (!lazyRequests && !hasValueDependencies) return "";
+	/** @type {(string | string[] | undefined)[][]} */
+	const valueEntries = [];
+	if (hasValueDependencies) {
+		const versions =
+			/** @type {NonNullable<BuildInfo["valueDependencies"]>} */
+			(valueDependencies);
+		for (const key of [...versions.keys()].sort()) {
+			const value = versions.get(key);
+			// An absent version serializes as null, distinct from both other shapes
+			valueEntries.push([
+				key,
+				value instanceof Set ? [...value].sort() : value
+			]);
+		}
+	}
+	// JSON, so a separator inside a request or a version cannot forge another entry
+	const joined = JSON.stringify([
+		lazyRequests ? [...lazyRequests] : [],
+		valueEntries
+	]);
 	if (joined.length < 100) return joined;
 	const hash = createHash(hashFunction);
 	hash.update(joined);
@@ -107,7 +132,7 @@ class FlagDependencyExportsPlugin {
 							const memCache = moduleMemCaches && moduleMemCaches.get(module);
 							/** @type {MemCacheEntry | undefined} */
 							const memCacheEntry = memCache && memCache.get(this);
-							const hash = getLazyRequestsHash(
+							const etag = getProvidedExportsEtag(
 								module,
 								lazyBarrelController,
 								hashFunction
@@ -116,7 +141,7 @@ class FlagDependencyExportsPlugin {
 							// detection cannot invalidate the mem cache when the un-lazied
 							// connections are unsafe-cached (they are skipped when comparing
 							// references)
-							if (memCacheEntry !== undefined && memCacheEntry.etag === hash) {
+							if (memCacheEntry !== undefined && memCacheEntry.etag === etag) {
 								statRestoredFromMemCache++;
 								exportsInfo.restoreProvided(memCacheEntry.data);
 								return callback();
@@ -126,7 +151,7 @@ class FlagDependencyExportsPlugin {
 							);
 							cache.get(
 								module.identifier(),
-								hash ? `${buildHash}|${hash}` : buildHash,
+								etag ? `${buildHash}|${etag}` : buildHash,
 								(err, result) => {
 									if (err) return callback(err);
 
@@ -351,6 +376,7 @@ class FlagDependencyExportsPlugin {
 
 											if (inlined !== undefined) {
 												const prev = exportInfo.canInlineProvide;
+												// Watch rebuilds keep ExportInfo; refresh when the constant changes
 												if (prev === undefined || !prev.equals(inlined)) {
 													exportInfo.canInlineProvide = inlined;
 													changed = true;
@@ -511,7 +537,7 @@ class FlagDependencyExportsPlugin {
 										.getRestoreProvidedData();
 									const memCache =
 										moduleMemCaches && moduleMemCaches.get(module);
-									const hash = getLazyRequestsHash(
+									const etag = getProvidedExportsEtag(
 										module,
 										lazyBarrelController,
 										hashFunction
@@ -519,7 +545,7 @@ class FlagDependencyExportsPlugin {
 									if (memCache) {
 										/** @type {MemCacheEntry} */
 										const entry = {
-											etag: hash,
+											etag,
 											data: cachedData
 										};
 										memCache.set(this, entry);
@@ -529,7 +555,7 @@ class FlagDependencyExportsPlugin {
 									);
 									cache.store(
 										module.identifier(),
-										hash ? `${buildHash}|${hash}` : buildHash,
+										etag ? `${buildHash}|${etag}` : buildHash,
 										cachedData,
 										callback
 									);

--- a/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
+++ b/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
@@ -14,7 +14,8 @@ const Template = require("../Template");
 const {
 	InlinedUsedName,
 	isExportInlined,
-	isInlineEnabled
+	isInlineEnabled,
+	isInlineExportsEnabled
 } = require("../optimize/InlineExports");
 const {
 	getKnownExportNames,
@@ -45,7 +46,8 @@ const processExportInfo = require("./processExportInfo");
  * 	RawReferencedExports,
  * 	ReferencedExports,
  * 	TRANSITIVE,
- * 	ExportInfoName
+ * 	ExportInfoName,
+ * 	UpdateHashContext
  * } from "../Dependency"
  */
 /** @import { DependencyTemplateContext } from "../DependencyTemplate" */
@@ -59,6 +61,7 @@ const processExportInfo = require("./processExportInfo");
  * } from "../Module"
  */
 /** @import ModuleGraph from "../ModuleGraph" */
+/** @import Hash from "../util/Hash" */
 /**
  * @import ModuleGraphConnection, {
  * 	ConnectionState
@@ -828,6 +831,31 @@ class HarmonyExportImportedSpecifierDependency extends HarmonyImportDependency {
 			}
 			return false;
 		};
+	}
+
+	/**
+	 * Updates the hash with the data contributed by this instance.
+	 * @param {Hash} hash hash to be updated
+	 * @param {UpdateHashContext} context context
+	 * @returns {void}
+	 */
+	updateHash(hash, context) {
+		const { chunkGraph, runtime } = context;
+		const moduleGraph = chunkGraph.moduleGraph;
+		if (!isInlineExportsEnabled(moduleGraph)) return;
+		const module = moduleGraph.getModule(this);
+		if (!module || !isInlineEnabled(module)) return;
+		const mode = this.getMode(moduleGraph, runtime);
+		if (mode.type !== "normal-reexport") return;
+		const exportsInfo = moduleGraph.getExportsInfo(module);
+		for (const item of /** @type {NormalReexportItem[]} */ (mode.items)) {
+			if (item.hidden || item.checked) continue;
+			const usedName = exportsInfo.getUsedName(item.ids, runtime);
+			if (usedName instanceof InlinedUsedName) {
+				hash.update(`${item.name}:${item.ids.join(".")}:`);
+				usedName.updateHash(hash);
+			}
+		}
 	}
 
 	/**

--- a/lib/dependencies/HarmonyImportSpecifierDependency.js
+++ b/lib/dependencies/HarmonyImportSpecifierDependency.js
@@ -30,6 +30,8 @@ const { ImportPhaseUtils } = require("./ImportPhase");
 /** @import { DependencyTemplateContext } from "../DependencyTemplate" */
 /** @import Module, { BuildMeta } from "../Module" */
 /** @import ModuleGraph from "../ModuleGraph" */
+/** @import { UpdateHashContext } from "../Dependency" */
+/** @import Hash from "../util/Hash" */
 /**
  * @import ModuleGraphConnection, {
  * 	ConnectionState
@@ -260,6 +262,28 @@ class HarmonyImportSpecifierDependency extends HarmonyImportDependency {
 		};
 		variants[slot] = condition;
 		return condition;
+	}
+
+	/**
+	 * Updates the hash with the data contributed by this instance.
+	 * @param {Hash} hash hash to be updated
+	 * @param {UpdateHashContext} context context
+	 * @returns {void}
+	 */
+	updateHash(hash, context) {
+		const { chunkGraph, runtime } = context;
+		const moduleGraph = chunkGraph.moduleGraph;
+		if (!isInlineExportsEnabled(moduleGraph)) return;
+		const module = moduleGraph.getModule(this);
+		if (!module || !isInlineEnabled(module)) return;
+		const ids = this.getIds(moduleGraph);
+		if (ids.length === 0) return;
+		const exportsInfo = moduleGraph.getExportsInfo(module);
+		if (!exportsInfo.hasInlinedUsedName(ids, runtime)) return;
+		const usedName = exportsInfo.getUsedName(ids, runtime);
+		if (usedName instanceof InlinedUsedName) {
+			usedName.updateHash(hash);
+		}
 	}
 
 	/**

--- a/lib/optimize/ConstExportsPlugin.js
+++ b/lib/optimize/ConstExportsPlugin.js
@@ -189,23 +189,13 @@ class ConstExportsPlugin {
 							}
 							for (const exportInfo of exportsInfo.ownedExports) {
 								const inlined = exportInfo.canInline();
-								if (inlined !== undefined && exportInfo.provided === true) {
-									if (!exportInfo.hasUsedName()) {
-										exportInfo.setUsedName(new InlinedUsedName(inlined));
-										exportsInfo.markInlinedExports();
-									} else {
-										// Watch rebuilds keep ExportInfo; refresh a stale literal
-										const usedName = exportInfo.getUsedName(
-											exportInfo.name,
-											undefined
-										);
-										if (
-											usedName instanceof InlinedUsedName &&
-											!usedName.value.equals(inlined)
-										) {
-											exportInfo.setUsedName(new InlinedUsedName(inlined));
-										}
-									}
+								const doInline =
+									!exportInfo.hasUsedName() &&
+									inlined !== undefined &&
+									exportInfo.provided === true;
+								if (doInline) {
+									exportInfo.setUsedName(new InlinedUsedName(inlined));
+									exportsInfo.markInlinedExports();
 								}
 								if (exportInfo.exportsInfoOwned && exportInfo.exportsInfo) {
 									const used = exportInfo.getUsed(undefined);

--- a/lib/optimize/InlineExports.js
+++ b/lib/optimize/InlineExports.js
@@ -17,6 +17,7 @@ const { propertyAccess } = require("../util/property");
 /** @import ModuleGraph from "../ModuleGraph" */
 /** @import Module from "../Module" */
 /** @import { RuntimeSpec } from "../util/runtime" */
+/** @import Hash from "../util/Hash" */
 
 const MAX_INLINE_BYTES = 6;
 
@@ -104,11 +105,20 @@ class InlinedUsedName {
 	}
 
 	/**
-	 * @param {string} comment leading comment text
+	 * @param {string=} comment leading comment text
 	 * @returns {string} rendered literal with property access suffix
 	 */
-	render(comment) {
+	render(comment = "") {
 		return this.value.render(comment) + propertyAccess(this.suffix);
+	}
+
+	/**
+	 * Updates the hash with the data contributed by this instance.
+	 * @param {Hash} hash the hash used to track dependencies
+	 * @returns {void}
+	 */
+	updateHash(hash) {
+		hash.update(this.render());
 	}
 }
 

--- a/lib/optimize/InlineExports.js
+++ b/lib/optimize/InlineExports.js
@@ -61,6 +61,14 @@ class InlinedValue {
 	}
 
 	/**
+	 * @param {InlinedValue} other other inlined value
+	 * @returns {boolean} true when kind and value match
+	 */
+	equals(other) {
+		return this.kind === other.kind && this.value === other.value;
+	}
+
+	/**
 	 * @param {ObjectSerializerContext} context context
 	 */
 	serialize({ write }) {

--- a/lib/optimize/InlineExports.js
+++ b/lib/optimize/InlineExports.js
@@ -61,14 +61,6 @@ class InlinedValue {
 	}
 
 	/**
-	 * @param {InlinedValue} other other inlined value
-	 * @returns {boolean} true when kind and value match
-	 */
-	equals(other) {
-		return this.kind === other.kind && this.value === other.value;
-	}
-
-	/**
 	 * @param {ObjectSerializerContext} context context
 	 */
 	serialize({ write }) {

--- a/test/watchCases/cache/inline-exports-value-change/0/index.js
+++ b/test/watchCases/cache/inline-exports-value-change/0/index.js
@@ -5,13 +5,14 @@ import "./trigger";
 const fs = __non_webpack_require__("fs");
 const path = __non_webpack_require__("path");
 
+const expectedFlag = WATCH_STEP === "0" ? "on" : "off";
+const expectedNum = WATCH_STEP === "2" ? 6 : 5;
+
 it("should refresh the inlined constants a cached build baked into consumers", () => {
 	const source = fs.readFileSync(
 		path.join(STATS_JSON.outputPath, "bundle.js"),
 		"utf8"
 	);
-	const expectedFlag = WATCH_STEP === "0" ? "on" : "off";
-	const expectedNum = WATCH_STEP === "2" ? 6 : 5;
 	expect(FLAG).toBe(expectedFlag);
 	expect(NUM).toBe(expectedNum);
 	expect(REEXPORTED_NUM).toBe(expectedNum);
@@ -20,3 +21,9 @@ it("should refresh the inlined constants a cached build baked into consumers", (
 	);
 	expect(source).toContain(`(/* inlined export .NUM */${expectedNum})`);
 });
+
+it("should refresh the literal a re-exporter with side effects bakes into its getter", () =>
+	import("./reexport-side-effect").then(({ SIDE_EFFECT_NUM }) => {
+		expect(SIDE_EFFECT_NUM).toBe(expectedNum);
+		delete global.__inlineExportsBarrel;
+	}));

--- a/test/watchCases/cache/inline-exports-value-change/0/reexport-side-effect.js
+++ b/test/watchCases/cache/inline-exports-value-change/0/reexport-side-effect.js
@@ -1,0 +1,4 @@
+// The side effect keeps this barrel from being skipped, so its getter is
+// where the literal lands
+global.__inlineExportsBarrel = true;
+export { NUM as SIDE_EFFECT_NUM } from "./env";

--- a/types.d.ts
+++ b/types.d.ts
@@ -11687,7 +11687,12 @@ declare class InitFragment<GenerateContext> {
 declare abstract class InlinedUsedName {
 	value: InlinedValue;
 	suffix: string[];
-	render(comment: string): string;
+	render(comment?: string): string;
+
+	/**
+	 * Updates the hash with the data contributed by this instance.
+	 */
+	updateHash(hash: Hash): void;
 }
 declare abstract class InlinedValue {
 	kind: InlinedValueKind;

--- a/types.d.ts
+++ b/types.d.ts
@@ -11694,6 +11694,7 @@ declare abstract class InlinedValue {
 	value?: null | string | number | boolean;
 	renderLiteral(): string;
 	render(comment: string): string;
+	equals(other: InlinedValue): boolean;
 	serialize(__0: ObjectSerializerContextObjectMiddlewareObject_3): void;
 	deserialize(__0: ObjectDeserializerContextObjectMiddlewareObject_2): void;
 }

--- a/types.d.ts
+++ b/types.d.ts
@@ -11694,7 +11694,6 @@ declare abstract class InlinedValue {
 	value?: null | string | number | boolean;
 	renderLiteral(): string;
 	render(comment: string): string;
-	equals(other: InlinedValue): boolean;
 	serialize(__0: ObjectSerializerContextObjectMiddlewareObject_3): void;
 	deserialize(__0: ObjectDeserializerContextObjectMiddlewareObject_2): void;
 }


### PR DESCRIPTION
**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Follow-up to #22020. Refs #22019. 

`ChunkGraph` hash only kept inlined `HarmonyImportSpecifierDependency` connections, so a re-exporter kept alive by its side effects still served a stale literal from its export getter after a cached rebuild. 

`HarmonyImportSpecifierDependency` and `HarmonyExportImportedSpecifierDependency` now feed the inlined literal into `updateHash` themselves, which replaces the `ChunkGraph` special case and the `ConstExportsPlugin` refresh branch it needed.

cc @xiaoxiaojx 
<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed stale cached values when exported constants change during watch mode.
  - Improved module graph tracking so inactive connections no longer affect rebuild results.
  - Ensured re-exported and imported values are correctly reflected when determining whether cached modules need updating.

- **Tests**
  - Added coverage for dynamic imports, side effects, and updated inlined export values in watch mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->