### PR TITLE
fix(concatenate-modules): keep the ASI guard of a wrapped reference outside the parentheses

### DIFF
--- a/.changeset/026-wrapped-assignment-asi-guard.md
+++ b/.changeset/026-wrapped-assignment-asi-guard.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Keep the ASI guard of a concatenated CommonJS assignment reference outside the parentheses.

--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -983,6 +983,9 @@ const getFinalName = (
 						? `;(0,${reference})`
 						: `/*#__PURE__*/Object(${reference})`;
 			} else if (binding.info.wrapped) {
+				if (asiSafe === false && reference.startsWith(";")) {
+					return `;(${reference.slice(1)})`;
+				}
 				return asiSafe === false ? `;(${reference})` : `(${reference})`;
 			}
 		} else if (accessorCall && !asCall) {

--- a/test/configCases/concatenate-modules/commonjs-wrapped-assignment-asi-position/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-assignment-asi-position/__snapshots__/ConfigCacheTest.snap
@@ -1,0 +1,453 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigCacheTestCases concatenate-modules commonjs-wrapped-assignment-asi-position commonjs-wrapped-assignment-asi-position should compile 1`] = `
+"/******/ (() => { // webpackBootstrap
+/******/ 	\\"use strict\\";
+/******/ 	// The require scope
+/******/ 	const __webpack_require__ = {};
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/compat get default export */
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = (module) => {
+/******/ 		const getter = module && module.__esModule ?
+/******/ 			() => (module['default']) :
+/******/ 			() => (module);
+/******/ 		__webpack_require__.d(getter, { a: getter });
+/******/ 		return getter;
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/concatenation wrap */
+/******/ 	// wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ 	// set before the body runs so re-entrant calls (require cycles) observe
+/******/ 	// the partial exports like Node.js
+/******/ 	__webpack_require__.cw = (body) => {
+/******/ 		var mod;
+/******/ 		return () => {
+/******/ 			if (body) {
+/******/ 				var fn = body;
+/******/ 				body = 0;
+/******/ 				mod = { exports: {} };
+/******/ 				fn.call(mod.exports, mod, mod.exports);
+/******/ 			}
+/******/ 			return mod.exports;
+/******/ 		};
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/define property getters */
+/******/ 	// define getter/value functions for harmony exports
+/******/ 	__webpack_require__.d = (exports, definition) => {
+/******/ 		for(var key in definition) {
+/******/ 			if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 				Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 			}
+/******/ 		}
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/hasOwnProperty shorthand */
+/******/ 	__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop));
+/******/ 	
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 1 modules ***!
+  \\\\******************************/
+
+// MODULE: ./vendor/wrapped.js
+var wrapped_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+var container = {
+	outputs: {
+		formats: {
+			text: {
+				wrap: function (state, entry) {
+					return entry;
+				}
+			},
+			html: {
+				wrap: function (state, entry) {
+					return entry;
+				}
+			}
+		}
+	}
+};
+
+module.exports = container;
+
+});
+
+;// ./vendor/wrapped.js
+wrapped_namespaceFn();
+
+function wrapped_default() { return wrapped_default.c || (wrapped_default.c = __webpack_require__.n(wrapped_namespaceFn())); }
+;// ./index.js
+
+
+const proxied = Symbol.for(\\"proxied\\");
+const getWrapper = (original) => {
+	const proxy = function (state, entry) {
+		return original.call(this, state, entry);
+	};
+	proxy[proxied] = true;
+	return proxy;
+};
+
+for (const format in ((wrapped_default()()).outputs).formats) {
+	const original = ((wrapped_default()()).outputs).formats[format][\\"wrap\\"];
+	if (!original || original[proxied]) {
+		continue;
+	}
+	;((wrapped_default()()).outputs).formats[format][\\"wrap\\"] = getWrapper(original);
+}
+
+it(\\"should wrap every entry without a syntax error\\", () => {
+	expect(
+		Object.values(((wrapped_default()()).outputs).formats).map(
+			(format) => format[\\"wrap\\"][proxied]
+		)
+	).toEqual([true, true]);
+});
+
+/******/ })()
+;"
+`;
+
+exports[`ConfigCacheTestCases concatenate-modules commonjs-wrapped-assignment-asi-position commonjs-wrapped-assignment-asi-position should compile 2`] = `
+"/******/ (() => { // webpackBootstrap
+/******/ 	\\"use strict\\";
+/******/ 	// The require scope
+/******/ 	const __webpack_require__ = {};
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/compat get default export */
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = (module) => {
+/******/ 		const getter = module && module.__esModule ?
+/******/ 			() => (module['default']) :
+/******/ 			() => (module);
+/******/ 		__webpack_require__.d(getter, { a: getter });
+/******/ 		return getter;
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/concatenation wrap */
+/******/ 	// wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ 	// set before the body runs so re-entrant calls (require cycles) observe
+/******/ 	// the partial exports like Node.js
+/******/ 	__webpack_require__.cw = (body) => {
+/******/ 		var mod;
+/******/ 		return () => {
+/******/ 			if (body) {
+/******/ 				var fn = body;
+/******/ 				body = 0;
+/******/ 				mod = { exports: {} };
+/******/ 				fn.call(mod.exports, mod, mod.exports);
+/******/ 			}
+/******/ 			return mod.exports;
+/******/ 		};
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/define property getters */
+/******/ 	// define getter/value functions for harmony exports
+/******/ 	__webpack_require__.d = (exports, definition) => {
+/******/ 		for(var key in definition) {
+/******/ 			if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 				Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 			}
+/******/ 		}
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/hasOwnProperty shorthand */
+/******/ 	__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop));
+/******/ 	
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 1 modules ***!
+  \\\\******************************/
+
+// MODULE: ./vendor/wrapped.js
+var wrapped_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+var container = {
+	outputs: {
+		formats: {
+			text: {
+				wrap: function (state, entry) {
+					return entry;
+				}
+			},
+			html: {
+				wrap: function (state, entry) {
+					return entry;
+				}
+			}
+		}
+	}
+};
+
+module.exports = container;
+
+});
+
+;// ./vendor/wrapped.js
+wrapped_namespaceFn();
+
+function wrapped_default() { return wrapped_default.c || (wrapped_default.c = __webpack_require__.n(wrapped_namespaceFn())); }
+;// ./index.js
+
+
+const proxied = Symbol.for(\\"proxied\\");
+const getWrapper = (original) => {
+	const proxy = function (state, entry) {
+		return original.call(this, state, entry);
+	};
+	proxy[proxied] = true;
+	return proxy;
+};
+
+for (const format in ((wrapped_default()()).outputs).formats) {
+	const original = ((wrapped_default()()).outputs).formats[format][\\"wrap\\"];
+	if (!original || original[proxied]) {
+		continue;
+	}
+	;((wrapped_default()()).outputs).formats[format][\\"wrap\\"] = getWrapper(original);
+}
+
+it(\\"should wrap every entry without a syntax error\\", () => {
+	expect(
+		Object.values(((wrapped_default()()).outputs).formats).map(
+			(format) => format[\\"wrap\\"][proxied]
+		)
+	).toEqual([true, true]);
+});
+
+/******/ })()
+;"
+`;
+
+exports[`ConfigCacheTestCases concatenate-modules commonjs-wrapped-assignment-asi-position commonjs-wrapped-assignment-asi-position should pre-compile to fill disk cache (1st) 1`] = `
+"/******/ (() => { // webpackBootstrap
+/******/ 	\\"use strict\\";
+/******/ 	// The require scope
+/******/ 	const __webpack_require__ = {};
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/compat get default export */
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = (module) => {
+/******/ 		const getter = module && module.__esModule ?
+/******/ 			() => (module['default']) :
+/******/ 			() => (module);
+/******/ 		__webpack_require__.d(getter, { a: getter });
+/******/ 		return getter;
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/concatenation wrap */
+/******/ 	// wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ 	// set before the body runs so re-entrant calls (require cycles) observe
+/******/ 	// the partial exports like Node.js
+/******/ 	__webpack_require__.cw = (body) => {
+/******/ 		var mod;
+/******/ 		return () => {
+/******/ 			if (body) {
+/******/ 				var fn = body;
+/******/ 				body = 0;
+/******/ 				mod = { exports: {} };
+/******/ 				fn.call(mod.exports, mod, mod.exports);
+/******/ 			}
+/******/ 			return mod.exports;
+/******/ 		};
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/define property getters */
+/******/ 	// define getter/value functions for harmony exports
+/******/ 	__webpack_require__.d = (exports, definition) => {
+/******/ 		for(var key in definition) {
+/******/ 			if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 				Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 			}
+/******/ 		}
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/hasOwnProperty shorthand */
+/******/ 	__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop));
+/******/ 	
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 1 modules ***!
+  \\\\******************************/
+
+// MODULE: ./vendor/wrapped.js
+var wrapped_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+var container = {
+	outputs: {
+		formats: {
+			text: {
+				wrap: function (state, entry) {
+					return entry;
+				}
+			},
+			html: {
+				wrap: function (state, entry) {
+					return entry;
+				}
+			}
+		}
+	}
+};
+
+module.exports = container;
+
+});
+
+;// ./vendor/wrapped.js
+wrapped_namespaceFn();
+
+function wrapped_default() { return wrapped_default.c || (wrapped_default.c = __webpack_require__.n(wrapped_namespaceFn())); }
+;// ./index.js
+
+
+const proxied = Symbol.for(\\"proxied\\");
+const getWrapper = (original) => {
+	const proxy = function (state, entry) {
+		return original.call(this, state, entry);
+	};
+	proxy[proxied] = true;
+	return proxy;
+};
+
+for (const format in ((wrapped_default()()).outputs).formats) {
+	const original = ((wrapped_default()()).outputs).formats[format][\\"wrap\\"];
+	if (!original || original[proxied]) {
+		continue;
+	}
+	;((wrapped_default()()).outputs).formats[format][\\"wrap\\"] = getWrapper(original);
+}
+
+it(\\"should wrap every entry without a syntax error\\", () => {
+	expect(
+		Object.values(((wrapped_default()()).outputs).formats).map(
+			(format) => format[\\"wrap\\"][proxied]
+		)
+	).toEqual([true, true]);
+});
+
+/******/ })()
+;"
+`;
+
+exports[`ConfigCacheTestCases concatenate-modules commonjs-wrapped-assignment-asi-position commonjs-wrapped-assignment-asi-position should pre-compile to fill disk cache (2nd) 1`] = `
+"/******/ (() => { // webpackBootstrap
+/******/ 	\\"use strict\\";
+/******/ 	// The require scope
+/******/ 	const __webpack_require__ = {};
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/compat get default export */
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = (module) => {
+/******/ 		const getter = module && module.__esModule ?
+/******/ 			() => (module['default']) :
+/******/ 			() => (module);
+/******/ 		__webpack_require__.d(getter, { a: getter });
+/******/ 		return getter;
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/concatenation wrap */
+/******/ 	// wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ 	// set before the body runs so re-entrant calls (require cycles) observe
+/******/ 	// the partial exports like Node.js
+/******/ 	__webpack_require__.cw = (body) => {
+/******/ 		var mod;
+/******/ 		return () => {
+/******/ 			if (body) {
+/******/ 				var fn = body;
+/******/ 				body = 0;
+/******/ 				mod = { exports: {} };
+/******/ 				fn.call(mod.exports, mod, mod.exports);
+/******/ 			}
+/******/ 			return mod.exports;
+/******/ 		};
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/define property getters */
+/******/ 	// define getter/value functions for harmony exports
+/******/ 	__webpack_require__.d = (exports, definition) => {
+/******/ 		for(var key in definition) {
+/******/ 			if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 				Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 			}
+/******/ 		}
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/hasOwnProperty shorthand */
+/******/ 	__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop));
+/******/ 	
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 1 modules ***!
+  \\\\******************************/
+
+// MODULE: ./vendor/wrapped.js
+var wrapped_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+var container = {
+	outputs: {
+		formats: {
+			text: {
+				wrap: function (state, entry) {
+					return entry;
+				}
+			},
+			html: {
+				wrap: function (state, entry) {
+					return entry;
+				}
+			}
+		}
+	}
+};
+
+module.exports = container;
+
+});
+
+;// ./vendor/wrapped.js
+wrapped_namespaceFn();
+
+function wrapped_default() { return wrapped_default.c || (wrapped_default.c = __webpack_require__.n(wrapped_namespaceFn())); }
+;// ./index.js
+
+
+const proxied = Symbol.for(\\"proxied\\");
+const getWrapper = (original) => {
+	const proxy = function (state, entry) {
+		return original.call(this, state, entry);
+	};
+	proxy[proxied] = true;
+	return proxy;
+};
+
+for (const format in ((wrapped_default()()).outputs).formats) {
+	const original = ((wrapped_default()()).outputs).formats[format][\\"wrap\\"];
+	if (!original || original[proxied]) {
+		continue;
+	}
+	;((wrapped_default()()).outputs).formats[format][\\"wrap\\"] = getWrapper(original);
+}
+
+it(\\"should wrap every entry without a syntax error\\", () => {
+	expect(
+		Object.values(((wrapped_default()()).outputs).formats).map(
+			(format) => format[\\"wrap\\"][proxied]
+		)
+	).toEqual([true, true]);
+});
+
+/******/ })()
+;"
+`;

--- a/test/configCases/concatenate-modules/commonjs-wrapped-assignment-asi-position/__snapshots__/ConfigTest.snap
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-assignment-asi-position/__snapshots__/ConfigTest.snap
@@ -1,0 +1,114 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigTestCases concatenate-modules commonjs-wrapped-assignment-asi-position commonjs-wrapped-assignment-asi-position should compile 1`] = `
+"/******/ (() => { // webpackBootstrap
+/******/ 	\\"use strict\\";
+/******/ 	// The require scope
+/******/ 	const __webpack_require__ = {};
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/compat get default export */
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = (module) => {
+/******/ 		const getter = module && module.__esModule ?
+/******/ 			() => (module['default']) :
+/******/ 			() => (module);
+/******/ 		__webpack_require__.d(getter, { a: getter });
+/******/ 		return getter;
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/concatenation wrap */
+/******/ 	// wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ 	// set before the body runs so re-entrant calls (require cycles) observe
+/******/ 	// the partial exports like Node.js
+/******/ 	__webpack_require__.cw = (body) => {
+/******/ 		var mod;
+/******/ 		return () => {
+/******/ 			if (body) {
+/******/ 				var fn = body;
+/******/ 				body = 0;
+/******/ 				mod = { exports: {} };
+/******/ 				fn.call(mod.exports, mod, mod.exports);
+/******/ 			}
+/******/ 			return mod.exports;
+/******/ 		};
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/define property getters */
+/******/ 	// define getter/value functions for harmony exports
+/******/ 	__webpack_require__.d = (exports, definition) => {
+/******/ 		for(var key in definition) {
+/******/ 			if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 				Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 			}
+/******/ 		}
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/hasOwnProperty shorthand */
+/******/ 	__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop));
+/******/ 	
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 1 modules ***!
+  \\\\******************************/
+
+// MODULE: ./vendor/wrapped.js
+var wrapped_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+var container = {
+	outputs: {
+		formats: {
+			text: {
+				wrap: function (state, entry) {
+					return entry;
+				}
+			},
+			html: {
+				wrap: function (state, entry) {
+					return entry;
+				}
+			}
+		}
+	}
+};
+
+module.exports = container;
+
+});
+
+;// ./vendor/wrapped.js
+wrapped_namespaceFn();
+
+function wrapped_default() { return wrapped_default.c || (wrapped_default.c = __webpack_require__.n(wrapped_namespaceFn())); }
+;// ./index.js
+
+
+const proxied = Symbol.for(\\"proxied\\");
+const getWrapper = (original) => {
+	const proxy = function (state, entry) {
+		return original.call(this, state, entry);
+	};
+	proxy[proxied] = true;
+	return proxy;
+};
+
+for (const format in ((wrapped_default()()).outputs).formats) {
+	const original = ((wrapped_default()()).outputs).formats[format][\\"wrap\\"];
+	if (!original || original[proxied]) {
+		continue;
+	}
+	;((wrapped_default()()).outputs).formats[format][\\"wrap\\"] = getWrapper(original);
+}
+
+it(\\"should wrap every entry without a syntax error\\", () => {
+	expect(
+		Object.values(((wrapped_default()()).outputs).formats).map(
+			(format) => format[\\"wrap\\"][proxied]
+		)
+	).toEqual([true, true]);
+});
+
+/******/ })()
+;"
+`;

--- a/test/configCases/concatenate-modules/commonjs-wrapped-assignment-asi-position/index.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-assignment-asi-position/index.js
@@ -1,0 +1,26 @@
+import wrapped from "wrapped";
+
+const proxied = Symbol.for("proxied");
+const getWrapper = (original) => {
+	const proxy = function (state, entry) {
+		return original.call(this, state, entry);
+	};
+	proxy[proxied] = true;
+	return proxy;
+};
+
+for (const format in wrapped.outputs.formats) {
+	const original = wrapped.outputs.formats[format]["wrap"];
+	if (!original || original[proxied]) {
+		continue;
+	}
+	wrapped.outputs.formats[format]["wrap"] = getWrapper(original);
+}
+
+it("should wrap every entry without a syntax error", () => {
+	expect(
+		Object.values(wrapped.outputs.formats).map(
+			(format) => format["wrap"][proxied]
+		)
+	).toEqual([true, true]);
+});

--- a/test/configCases/concatenate-modules/commonjs-wrapped-assignment-asi-position/vendor/wrapped.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-assignment-asi-position/vendor/wrapped.js
@@ -1,0 +1,20 @@
+"use strict";
+
+var container = {
+	outputs: {
+		formats: {
+			text: {
+				wrap: function (state, entry) {
+					return entry;
+				}
+			},
+			html: {
+				wrap: function (state, entry) {
+					return entry;
+				}
+			}
+		}
+	}
+};
+
+module.exports = container;

--- a/test/configCases/concatenate-modules/commonjs-wrapped-assignment-asi-position/webpack.config.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-assignment-asi-position/webpack.config.js
@@ -1,0 +1,34 @@
+"use strict";
+
+const path = require("path");
+
+const PLUGIN_NAME = "SnapshotBundlePlugin";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	devtool: false,
+	resolve: {
+		modules: [path.resolve(__dirname, "vendor"), "node_modules"]
+	},
+	optimization: {
+		concatenateModules: { commonjs: true },
+		minimize: false,
+		usedExports: true,
+		moduleIds: "named",
+		chunkIds: "named"
+	},
+	plugins: [
+		/**
+		 * What this case checks is printed code, so review the bundle as a whole.
+		 * @param {import("../../../../").Compiler} compiler compiler
+		 */
+		(compiler) => {
+			compiler.hooks.compilation.tap(PLUGIN_NAME, (compilation) => {
+				compilation.hooks.afterProcessAssets.tap(PLUGIN_NAME, (assets) => {
+					expect(assets["bundle0.js"].source()).toMatchSnapshot();
+				});
+			});
+		}
+	]
+};


### PR DESCRIPTION
Fixes #22052

### Motivation

`ModuleConcatenationPlugin` emits invalid JavaScript when a wrapped CommonJS
module's reference lands at a statement ASI position: `getFinalName` re-wraps
the reference and prepends its own ASI guard without stripping the guard
already embedded inside the reference by `getFinalBinding`, producing
`;(;(accessor()()).prop)` — a stray `;` inside the parentheses that throws
`SyntaxError: Unexpected token ';'` at parse time.

Introduced in a6d13aac4 (*feat: wrap concatenated ESM/CJS and inline CJS
require edges*, #21519). Details and repro in #<issue-number>.

### What the fix does

In the `binding.info.wrapped` branch of `getFinalName`, when the reference
already carries a guard (`asiSafe === false && reference.startsWith(";")`),
emit the guard outside the new parentheses instead of nesting it:

```js
return `;(${reference.slice(1)})`;
```

### Tests

- New regression fixture `test/configCases/concatenate-modules/commonjs-wrapped-assignment-asi-position`:
  resolves a CommonJS module from a bare specifier through `resolve.modules`
  (single file, no `package.json`, exports statically unknown) and writes a
  nested-property assignment after a block so the reference starts at an ASI
  position. Without the fix the emitted bundle throws
  `SyntaxError: Unexpected token ';'`; with the fix it parses and runs.
- Printed-source snapshots for both `ConfigTestCases` and
  `ConfigCacheTestCases` capture the corrected emission
  (`;((citeproc_default()()).Output)...`).
- The full `concatenate-modules` category (352 tests) passes.

### Changelog

`.changeset/026-wrapped-assignment-asi-guard.md` (patch).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed generated CommonJS assignments to avoid duplicated semicolons in certain wrapped module references.
  * Preserved correct automatic semicolon insertion behavior when concatenating modules.

* **Tests**
  * Added coverage for wrapped CommonJS assignments across supported output formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->