### PR TITLE
fix(config): default output.module to true when using module library type

### DIFF
--- a/.changeset/008-library-module-output-default.md
+++ b/.changeset/008-library-module-output-default.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Default `output.module` to `true` when using `library.type: "module"` or `"modern-module"`, and throw if `output.module` is explicitly disabled.

--- a/lib/WebpackOptionsApply.js
+++ b/lib/WebpackOptionsApply.js
@@ -502,6 +502,19 @@ class WebpackOptionsApply extends OptionsApply {
 			sideEffectFree: options.experiments.futureDefaults
 		}).apply(compiler);
 
+		if (!options.output.module) {
+			if (options.output.enabledLibraryTypes.includes("module")) {
+				throw new Error(
+					"library type \"module\" is only allowed when 'output.module' is enabled"
+				);
+			}
+			if (options.output.enabledLibraryTypes.includes("modern-module")) {
+				throw new Error(
+					"library type \"modern-module\" is only allowed when 'output.module' is enabled"
+				);
+			}
+		}
+
 		if (options.output.module) {
 			// Analyzable output is ESM output, so this is every build that can reserve a name.
 			const RuntimeTemplate = require("./RuntimeTemplate");

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -1640,14 +1640,47 @@ const applyOutputDefaults = (
 		}
 	});
 
-	// the universal target (web + node, neither specific), deno and bun only work
-	// as ESM, unless `module: false` says the target cannot read one
+	/**
+	 * Processes the provided fn.
+	 * @param {(entryDescription: EntryDescription) => void} fn iterator
+	 * @returns {void}
+	 */
+	const forEachEntry = (fn) => {
+		for (const name of Object.keys(entry)) {
+			fn(/** @type {{ [k: string]: EntryDescription }} */ (entry)[name]);
+		}
+	};
+
+	const hasModuleLibrary = () => {
+		if (
+			output.library &&
+			(output.library.type === "module" ||
+				output.library.type === "modern-module")
+		) {
+			return true;
+		}
+		let hasModule = false;
+		forEachEntry((desc) => {
+			if (
+				desc.library &&
+				(desc.library.type === "module" ||
+					desc.library.type === "modern-module")
+			) {
+				hasModule = true;
+			}
+		});
+		return hasModule;
+	};
+
+	// the universal target (web + node, neither specific), deno, bun and module
+	// libraries only work as ESM, unless `module: false` says the target cannot read one
 	F(output, "module", () =>
 		Boolean(
-			tp &&
-			((tp.node === null && tp.web === null && tp.module !== false) ||
-				tp.deno === true ||
-				tp.bun === true)
+			hasModuleLibrary() ||
+			(tp &&
+				((tp.node === null && tp.web === null && tp.module !== false) ||
+					tp.deno === true ||
+					tp.bun === true))
 		)
 	);
 
@@ -2122,16 +2155,6 @@ const applyOutputDefaults = (
 		D(trustedTypes, "onPolicyCreationFailure", "stop");
 	}
 
-	/**
-	 * Processes the provided fn.
-	 * @param {(entryDescription: EntryDescription) => void} fn iterator
-	 * @returns {void}
-	 */
-	const forEachEntry = (fn) => {
-		for (const name of Object.keys(entry)) {
-			fn(/** @type {{ [k: string]: EntryDescription }} */ (entry)[name]);
-		}
-	};
 	A(output, "enabledLibraryTypes", () => {
 		/** @type {LibraryType[]} */
 		const enabledLibraryTypes = [];

--- a/test/Defaults.unittest.js
+++ b/test/Defaults.unittest.js
@@ -6175,4 +6175,83 @@ describe("optimization.minimize", () => {
 			html: false
 		});
 	});
+
+	describe("library module output defaults", () => {
+		it("should default output.module to true when library.type is module", () => {
+			const config = getDefaultConfig({
+				mode: "none",
+				output: {
+					library: {
+						type: "module"
+					}
+				}
+			});
+			expect(config.output.module).toBe(true);
+		});
+
+		it("should default output.module to true when library.type is modern-module", () => {
+			const config = getDefaultConfig({
+				mode: "none",
+				output: {
+					library: {
+						type: "modern-module"
+					}
+				}
+			});
+			expect(config.output.module).toBe(true);
+		});
+
+		it("should default output.module to true when entry library.type is module", () => {
+			const config = getDefaultConfig({
+				mode: "none",
+				entry: {
+					main: {
+						import: "./src",
+						library: {
+							type: "module"
+						}
+					}
+				}
+			});
+			expect(config.output.module).toBe(true);
+		});
+
+		it("should throw when library.type is module and output.module is false", () => {
+			const webpack = require("..");
+
+			expect(() => {
+				webpack({
+					mode: "none",
+					entry: "./src",
+					output: {
+						module: false,
+						library: {
+							type: "module"
+						}
+					}
+				});
+			}).toThrow(
+				"library type \"module\" is only allowed when 'output.module' is enabled"
+			);
+		});
+
+		it("should throw when library.type is modern-module and output.module is false", () => {
+			const webpack = require("..");
+
+			expect(() => {
+				webpack({
+					mode: "none",
+					entry: "./src",
+					output: {
+						module: false,
+						library: {
+							type: "modern-module"
+						}
+					}
+				});
+			}).toThrow(
+				"library type \"modern-module\" is only allowed when 'output.module' is enabled"
+			);
+		});
+	});
 });

--- a/test/configCases/library/module-default-output-module/dep.js
+++ b/test/configCases/library/module-default-output-module/dep.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/test/configCases/library/module-default-output-module/index.js
+++ b/test/configCases/library/module-default-output-module/index.js
@@ -1,0 +1,9 @@
+import value from "./dep";
+
+export default value;
+export const name = "module-lib";
+
+it("should run as an ES module when library.type is module without explicit output.module", () => {
+	expect(value).toBe(42);
+	expect(name).toBe("module-lib");
+});

--- a/test/configCases/library/module-default-output-module/test.config.js
+++ b/test/configCases/library/module-default-output-module/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["main.mjs"];
+	}
+};

--- a/test/configCases/library/module-default-output-module/webpack.config.js
+++ b/test/configCases/library/module-default-output-module/webpack.config.js
@@ -1,0 +1,12 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	output: {
+		filename: "[name].mjs",
+		library: {
+			type: "module"
+		}
+	}
+};

--- a/test/harness/runner/index.js
+++ b/test/harness/runner/index.js
@@ -480,8 +480,12 @@ class TestRunner {
 		}
 		if (
 			modulePath.endsWith(".mjs") &&
-			this.webpackOptions.output &&
-			this.webpackOptions.output.module
+			((this.webpackOptions.output &&
+				(this.webpackOptions.output.module ||
+					(this.webpackOptions.output.library &&
+						(this.webpackOptions.output.library.type === "module" ||
+							this.webpackOptions.output.library.type === "modern-module")))) ||
+				TestRunner.isUniversalTarget(this.webpackOptions))
 		) {
 			return this._moduleRunners.esm(moduleInfo, context);
 		}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Setting `output.library.type` (or `entry[name].library.type`) to `module` or `modern-module` previously left `output.module` defaulted to `false`. Because `output.module` was `false`, `output.iife` defaulted to `true`, causing webpack to emit export statements inside an IIFE `(() => { ... export default ...; })()`. This caused runtime `SyntaxError: Unexpected token 'export'` and failed Terser minification in production.

This PR:
- Defaults `output.module` to `true` in `lib/config/defaults.js` when `output.library.type` or any entry `library.type` is `module` or `modern-module`.
- Throws a descriptive configuration error in `lib/WebpackOptionsApply.js` when `output.module` is explicitly disabled with a module library.
- Dispatches test runner `.mjs` executions to ESM when library type is `module` or `modern-module`.

Fixes #22061.

**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

Yes:
- Unit tests in `test/Defaults.unittest.js`
- Integration test in `test/configCases/library/module-default-output-module/`

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Module and modern-module libraries now automatically enable module output by default.
  * Builds using these library types now provide clearer validation when module output is explicitly disabled.
  * Universal and modern module bundles are correctly executed as ES modules during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->