### PR TITLE
fix(config): normalize file URLs in dotenv, buildHttp, noParse and resolve.restrictions

### DIFF
--- a/.changeset/007-file-url-paths.md
+++ b/.changeset/007-file-url-paths.md
@@ -2,4 +2,4 @@
 "webpack": minor
 ---
 
-Accept file URLs where an option takes an absolute path.
+Accept file URLs in all options that take an absolute path.

--- a/lib/config/normalization.js
+++ b/lib/config/normalization.js
@@ -280,7 +280,10 @@ const getNormalizedWebpackOptions = (config) => ({
 		return { ...devServer };
 	}),
 	devtool: config.devtool,
-	dotenv: config.dotenv,
+	dotenv:
+		typeof config.dotenv === "object" && config.dotenv !== null
+			? { ...config.dotenv, dir: optionalFileUrlToPath(config.dotenv.dir) }
+			: config.dotenv,
 	entry:
 		config.entry === undefined
 			? { main: {} }
@@ -293,7 +296,13 @@ const getNormalizedWebpackOptions = (config) => ({
 	experiments: nestedConfig(config.experiments, (experiments) => ({
 		...experiments,
 		buildHttp: optionalNestedConfig(experiments.buildHttp, (options) =>
-			Array.isArray(options) ? { allowedUris: options } : options
+			Array.isArray(options)
+				? { allowedUris: options }
+				: {
+						...options,
+						cacheLocation: optionalFileUrlToPath(options.cacheLocation),
+						lockfileLocation: optionalFileUrlToPath(options.lockfileLocation)
+					}
 		),
 		lazyCompilation: optionalNestedConfig(
 			experiments.lazyCompilation,
@@ -340,7 +349,14 @@ const getNormalizedWebpackOptions = (config) => ({
 		/** @type {ModuleOptionsNormalized} */
 		(
 			nestedConfig(config.module, (module) => ({
-				noParse: module.noParse,
+				noParse:
+					typeof module.noParse === "string"
+						? fileUrlToPath(module.noParse)
+						: Array.isArray(module.noParse)
+							? module.noParse.map((rule) =>
+									typeof rule === "string" ? fileUrlToPath(rule) : rule
+								)
+							: module.noParse,
 				unsafeCache: module.unsafeCache,
 				parser: keyedNestedConfig(module.parser, cloneObject, {
 					javascript: (parserOptions) => ({
@@ -555,7 +571,8 @@ const getNormalizedWebpackOptions = (config) => ({
 	),
 	resolve: nestedConfig(config.resolve, (resolve) => ({
 		...resolve,
-		byDependency: keyedNestedConfig(resolve.byDependency, cloneObject)
+		byDependency: keyedNestedConfig(resolve.byDependency, cloneObject),
+		restrictions: optionalNestedArray(resolve.restrictions, fileUrlsToPaths)
 	})),
 	resolveLoader: cloneObject(config.resolveLoader),
 	snapshot: nestedConfig(config.snapshot, (snapshot) => ({

--- a/test/Normalization.unittest.js
+++ b/test/Normalization.unittest.js
@@ -52,5 +52,38 @@ describe("getNormalizedWebpackOptions", () => {
 			expect(options.recordsInputPath).toBe(false);
 			expect(options.snapshot.managedPaths).toEqual([directory, expression]);
 		});
+
+		it("converts file URLs in dotenv.dir, buildHttp paths, module.noParse and resolve.restrictions", () => {
+			const expression = /node_modules/;
+			const options = getNormalizedWebpackOptions({
+				dotenv: { dir: url },
+				experiments: {
+					buildHttp: {
+						allowedUris: ["https://example.com"],
+						cacheLocation: url,
+						lockfileLocation: url
+					}
+				},
+				module: { noParse: url },
+				resolve: { restrictions: [url, expression] }
+			});
+
+			expect(options.dotenv.dir).toBe(directory);
+			expect(options.experiments.buildHttp).toMatchObject({
+				cacheLocation: directory,
+				lockfileLocation: directory
+			});
+			expect(options.module.noParse).toBe(directory);
+			expect(options.resolve.restrictions).toEqual([directory, expression]);
+		});
+
+		it("converts file URLs inside a module.noParse array", () => {
+			const expression = /vendor/;
+			const options = getNormalizedWebpackOptions({
+				module: { noParse: [url, expression] }
+			});
+
+			expect(options.module.noParse).toEqual([directory, expression]);
+		});
 	});
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

#22012 added file-URL normalization for `context`, `output.path`, cache paths and snapshot paths, but four `absolutePath` options were not covered: `dotenv.dir`, `experiments.buildHttp.cacheLocation`/`lockfileLocation`, `module.noParse` (string and array-of-string forms), and `resolve.restrictions` items. A file URL in any of these was passed through unchanged, so it never matched an OS path and the option silently had no effect.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes — two new `it` blocks in `test/Normalization.unittest.js` covering all four options (scalar `noParse` and array `noParse` separately).

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

Claude Code was used to identify the gaps by cross-referencing every `"absolutePath": true` property in `schemas/WebpackOptions.json` against the normalization call-sites, and to draft the fix and tests. All generated code was reviewed and verified manually before submission. See the [webpack AI policy](https://github.com/webpack/governance/blob/main/AI_POLICY.md).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - File URLs are now converted to absolute paths across additional configuration options, including dotenv directories, build cache locations, lockfile locations, module parsing exclusions, and resolve restrictions.
  - Regular expression entries and non-string values continue to be preserved during normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->