### PR TITLE
fix(config): normalize file URLs for options taking absolute paths

### DIFF
--- a/.changeset/007-file-url-normalization.md
+++ b/.changeset/007-file-url-normalization.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Normalize file URLs in `module.noParse`, `resolve.restrictions`, `resolveLoader.restrictions`, `stats.context`, `dotenv.dir`, and `experiments.buildHttp`.

--- a/lib/config/normalization.js
+++ b/lib/config/normalization.js
@@ -162,6 +162,21 @@ const fileUrlsToPaths = (pathsOrUrls) =>
 	);
 
 /**
+ * Normalizes `module.noParse` converting any file URLs to paths.
+ * @param {import("../../declarations/WebpackOptions").NoParse=} noParse noParse option
+ * @returns {import("../../declarations/WebpackOptions").NoParse | undefined} normalized noParse
+ */
+const normalizeNoParse = (noParse) => {
+	if (typeof noParse === "string") {
+		return fileUrlToPath(noParse);
+	}
+	if (Array.isArray(noParse)) {
+		return fileUrlsToPaths(noParse);
+	}
+	return noParse;
+};
+
+/**
  * Normalize `output.resourceHints` into its object form: the scalar / array /
  * function shorthand becomes `{ initial: <value> }` (with `"preload"` aliased to
  * `true`); an object is passed through, its `initial` getting the same alias.
@@ -280,7 +295,17 @@ const getNormalizedWebpackOptions = (config) => ({
 		return { ...devServer };
 	}),
 	devtool: config.devtool,
-	dotenv: config.dotenv,
+	dotenv: optionalNestedConfig(config.dotenv, (dotenv) => {
+		if (typeof dotenv === "object" && dotenv !== null) {
+			return {
+				...dotenv,
+				...(dotenv.dir !== undefined && {
+					dir: optionalFileUrlToPath(dotenv.dir)
+				})
+			};
+		}
+		return dotenv;
+	}),
 	entry:
 		config.entry === undefined
 			? { main: {} }
@@ -292,9 +317,20 @@ const getNormalizedWebpackOptions = (config) => ({
 				: getNormalizedEntryStatic(config.entry),
 	experiments: nestedConfig(config.experiments, (experiments) => ({
 		...experiments,
-		buildHttp: optionalNestedConfig(experiments.buildHttp, (options) =>
-			Array.isArray(options) ? { allowedUris: options } : options
-		),
+		buildHttp: optionalNestedConfig(experiments.buildHttp, (options) => {
+			const values = Array.isArray(options)
+				? { allowedUris: options }
+				: options;
+			return {
+				...values,
+				...(values.cacheLocation !== undefined && {
+					cacheLocation: optionalFileUrlToPath(values.cacheLocation)
+				}),
+				...(values.lockfileLocation !== undefined && {
+					lockfileLocation: optionalFileUrlToPath(values.lockfileLocation)
+				})
+			};
+		}),
 		lazyCompilation: optionalNestedConfig(
 			experiments.lazyCompilation,
 			(options) => (options === true ? {} : options)
@@ -340,7 +376,7 @@ const getNormalizedWebpackOptions = (config) => ({
 		/** @type {ModuleOptionsNormalized} */
 		(
 			nestedConfig(config.module, (module) => ({
-				noParse: module.noParse,
+				noParse: normalizeNoParse(module.noParse),
 				unsafeCache: module.unsafeCache,
 				parser: keyedNestedConfig(module.parser, cloneObject, {
 					javascript: (parserOptions) => ({
@@ -555,9 +591,17 @@ const getNormalizedWebpackOptions = (config) => ({
 	),
 	resolve: nestedConfig(config.resolve, (resolve) => ({
 		...resolve,
+		...(resolve.restrictions !== undefined && {
+			restrictions: fileUrlsToPaths(resolve.restrictions)
+		}),
 		byDependency: keyedNestedConfig(resolve.byDependency, cloneObject)
 	})),
-	resolveLoader: cloneObject(config.resolveLoader),
+	resolveLoader: nestedConfig(config.resolveLoader, (resolveLoader) => ({
+		...resolveLoader,
+		...(resolveLoader.restrictions !== undefined && {
+			restrictions: fileUrlsToPaths(resolveLoader.restrictions)
+		})
+	})),
 	snapshot: nestedConfig(config.snapshot, (snapshot) => ({
 		resolveBuildDependencies: optionalNestedConfig(
 			snapshot.resolveBuildDependencies,
@@ -615,7 +659,10 @@ const getNormalizedWebpackOptions = (config) => ({
 			};
 		}
 		return {
-			...stats
+			...stats,
+			...(stats.context !== undefined && {
+				context: optionalFileUrlToPath(stats.context)
+			})
 		};
 	}),
 	target: config.target,

--- a/test/Normalization.unittest.js
+++ b/test/Normalization.unittest.js
@@ -19,10 +19,31 @@ describe("getNormalizedWebpackOptions", () => {
 					cacheDirectory: url,
 					cacheLocation: url
 				},
+				dotenv: {
+					dir: url
+				},
+				experiments: {
+					buildHttp: {
+						cacheLocation: url,
+						lockfileLocation: url
+					}
+				},
+				module: {
+					noParse: url
+				},
+				resolve: {
+					restrictions: [url]
+				},
+				resolveLoader: {
+					restrictions: [url]
+				},
 				snapshot: {
 					immutablePaths: [url],
 					managedPaths: [url],
 					unmanagedPaths: [url]
+				},
+				stats: {
+					context: url
 				}
 			});
 
@@ -35,9 +56,20 @@ describe("getNormalizedWebpackOptions", () => {
 				cacheDirectory: directory,
 				cacheLocation: directory
 			});
+			expect(options.dotenv).toMatchObject({
+				dir: directory
+			});
+			expect(options.experiments.buildHttp).toMatchObject({
+				cacheLocation: directory,
+				lockfileLocation: directory
+			});
+			expect(options.module.noParse).toBe(directory);
+			expect(options.resolve.restrictions).toEqual([directory]);
+			expect(options.resolveLoader.restrictions).toEqual([directory]);
 			expect(options.snapshot.immutablePaths).toEqual([directory]);
 			expect(options.snapshot.managedPaths).toEqual([directory]);
 			expect(options.snapshot.unmanagedPaths).toEqual([directory]);
+			expect(options.stats.context).toBe(directory);
 		});
 
 		it("leaves a plain path and a regular expression alone", () => {
@@ -45,12 +77,41 @@ describe("getNormalizedWebpackOptions", () => {
 			const options = getNormalizedWebpackOptions({
 				context: directory,
 				recordsPath: false,
-				snapshot: { managedPaths: [directory, expression] }
+				dotenv: { dir: directory },
+				experiments: {
+					buildHttp: {
+						cacheLocation: directory,
+						lockfileLocation: directory
+					}
+				},
+				module: {
+					noParse: [directory, expression]
+				},
+				resolve: {
+					restrictions: [directory, expression]
+				},
+				resolveLoader: {
+					restrictions: [directory, expression]
+				},
+				snapshot: { managedPaths: [directory, expression] },
+				stats: { context: directory }
 			});
 
 			expect(options.context).toBe(directory);
 			expect(options.recordsInputPath).toBe(false);
+			expect(options.dotenv).toMatchObject({ dir: directory });
+			expect(options.experiments.buildHttp).toMatchObject({
+				cacheLocation: directory,
+				lockfileLocation: directory
+			});
+			expect(options.module.noParse).toEqual([directory, expression]);
+			expect(options.resolve.restrictions).toEqual([directory, expression]);
+			expect(options.resolveLoader.restrictions).toEqual([
+				directory,
+				expression
+			]);
 			expect(options.snapshot.managedPaths).toEqual([directory, expression]);
+			expect(options.stats.context).toBe(directory);
 		});
 	});
 });

--- a/test/configCases/no-parse/file-url/dep.js
+++ b/test/configCases/no-parse/file-url/dep.js
@@ -1,0 +1,1 @@
+module.exports = "parsed dep";

--- a/test/configCases/no-parse/file-url/index.js
+++ b/test/configCases/no-parse/file-url/index.js
@@ -1,0 +1,8 @@
+it("should not parse modules matching file URLs in noParse", () => {
+	expect(require("./not-parsed-a")).toBe("a");
+	expect(require("./not-parsed-b")).toBe("b");
+});
+
+it("should parse other modules", () => {
+	expect(require("./parsed")).toBe("parsed dep");
+});

--- a/test/configCases/no-parse/file-url/not-parsed-a.js
+++ b/test/configCases/no-parse/file-url/not-parsed-a.js
@@ -1,0 +1,2 @@
+if (module.exports === 42) require("./does-not-exist-a");
+module.exports = "a";

--- a/test/configCases/no-parse/file-url/not-parsed-b.js
+++ b/test/configCases/no-parse/file-url/not-parsed-b.js
@@ -1,0 +1,2 @@
+if (module.exports === 42) require("./does-not-exist-b");
+module.exports = "b";

--- a/test/configCases/no-parse/file-url/parsed.js
+++ b/test/configCases/no-parse/file-url/parsed.js
@@ -1,0 +1,1 @@
+module.exports = require("./dep");

--- a/test/configCases/no-parse/file-url/test.filter.js
+++ b/test/configCases/no-parse/file-url/test.filter.js
@@ -1,0 +1,5 @@
+"use strict";
+
+const supportsFileUrlPaths = require("../../../helpers/supportsFileUrlPaths");
+
+module.exports = () => supportsFileUrlPaths();

--- a/test/configCases/no-parse/file-url/webpack.config.js
+++ b/test/configCases/no-parse/file-url/webpack.config.js
@@ -1,0 +1,14 @@
+"use strict";
+
+const path = require("path");
+const { pathToFileURL } = require("url");
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	module: {
+		noParse: [
+			pathToFileURL(path.resolve(__dirname, "not-parsed-a")).href,
+			pathToFileURL(path.resolve(__dirname, "not-parsed-b")).href
+		]
+	}
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

In #22012 / commit 3a69d296, webpack added support for `file://` URLs wherever options take an absolute path, converting them during options normalization in `lib/config/normalization.js` for options like `context`, `output.path`, `snapshot.managedPaths`, `cacheDirectory`, etc.

However, several other options that take `"absolutePath": true` per `schemas/WebpackOptions.json` were omitted from normalization:
- `module.noParse`: `NormalModule.applyNoParseRule` compares `content.startsWith(rule)`. Since `content` is a filesystem path and `rule` remained a `file://` URL, they never matched, causing modules to be parsed unexpectedly.
- `resolve.restrictions` & `resolveLoader.restrictions`: passed directly to `enhanced-resolve` as `file://` URLs, causing resolution failures for allowed paths.
- `stats.context`: passed to `RequestShortener` / `contextify` without normalization, causing broken relative paths.
- `dotenv.dir` & `experiments.buildHttp`: passed to path utilities expecting filesystem paths.

This PR normalizes file URLs to filesystem paths for these options in `lib/config/normalization.js`.

Fixes #22057.

**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

Yes:
- Unit tests in `test/Normalization.unittest.js` covering normalization of `module.noParse`, `resolve.restrictions`, `resolveLoader.restrictions`, `stats.context`, `dotenv.dir`, and `experiments.buildHttp`.
- Integration config test in `test/configCases/no-parse/file-url/` (gated with `supportsFileUrlPaths()` matching `test/configCases/rule-set/file-url-condition/`).

**Does this PR introduce a breaking change?**

No. Non-file-URL values, RegExps, and functions pass through unchanged.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File URLs are now consistently normalized to paths across supported configuration options, including module parsing, resolver restrictions, statistics context, dotenv settings, and HTTP build settings.
  * Existing path, regular expression, and array-based configuration formats remain supported.
  * Improved handling of loader resolution settings while preserving other configuration values.

* **Tests**
  * Added coverage confirming file URL support and correct parsing behavior for excluded modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->