### PR TITLE
fix(identifier): throw clear error for host-based file URLs on POSIX

### DIFF
--- a/.changeset/024-file-url-host-error.md
+++ b/.changeset/024-file-url-host-error.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Throw a clear error when a file URL with a non-localhost hostname is used as an option value.

--- a/.changeset/024-file-url-host-error.md
+++ b/.changeset/024-file-url-host-error.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Include the URL in file URL conversion errors.
+Include the URL in file URL conversion errors. 

--- a/.changeset/024-file-url-host-error.md
+++ b/.changeset/024-file-url-host-error.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Throw a clear error when a file URL with a non-localhost hostname is used as an option value.
+Include the URL in file URL conversion errors.

--- a/lib/dependencies/CreateRequireParserPlugin.js
+++ b/lib/dependencies/CreateRequireParserPlugin.js
@@ -5,7 +5,6 @@
 
 "use strict";
 
-const { fileURLToPath } = require("url");
 const WebpackError = require("../errors/WebpackError");
 const BasicEvaluatedExpression = require("../javascript/BasicEvaluatedExpression");
 const { VariableInfo } = require("../javascript/JavascriptParser");
@@ -14,6 +13,7 @@ const {
 	expressionIsUnsupported,
 	toConstantDependency
 } = require("../javascript/JavascriptParserHelpers");
+const { fileUrlToPath } = require("../util/identifier");
 const CommonJsImportsParserPlugin = require("./CommonJsImportsParserPlugin");
 const ConstDependency = require("./ConstDependency");
 
@@ -180,9 +180,7 @@ class CreateRequireParserPlugin {
 				parser.state.module.addWarning(err);
 				return;
 			}
-			const ctx = /** @type {string} */ (evaluated.string).startsWith("file://")
-				? fileURLToPath(/** @type {string} */ (evaluated.string))
-				: /** @type {string} */ (evaluated.string);
+			const ctx = fileUrlToPath(/** @type {string} */ (evaluated.string));
 			// argument always should be a filename
 			return ctx.slice(0, ctx.lastIndexOf(ctx.startsWith("/") ? "/" : "\\"));
 		};

--- a/lib/util/identifier.js
+++ b/lib/util/identifier.js
@@ -27,7 +27,14 @@ const FILE_URL_REGEXP = /^file:\/\//i;
  */
 const fileUrlToPath = (pathOrUrl) => {
 	if (!FILE_URL_REGEXP.test(pathOrUrl)) return pathOrUrl;
-	return fileURLToPath(pathOrUrl);
+	try {
+		return fileURLToPath(pathOrUrl);
+	} catch (err) {
+		throw new Error(
+			`Cannot convert file URL to path: ${/** @type {Error} */ (err).message} (${pathOrUrl})`,
+			{ cause: err }
+		);
+	}
 };
 
 /**

--- a/test/identifier.unittest.js
+++ b/test/identifier.unittest.js
@@ -322,5 +322,13 @@ describe("util/identifier", () => {
 				expect(fileUrlToPath(value)).toBe(value);
 			}
 		});
+
+		if (process.platform !== "win32") {
+			it("throws a clear error for a host-based file URL on POSIX", () => {
+				expect(() => fileUrlToPath("file://hostname/path")).toThrow(
+					/file:\/\/hostname\/path/
+				);
+			});
+		}
 	});
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

`fileUrlToPath` in `lib/util/identifier.js` called `fileURLToPath` with no error handling, so a `file://hostname/path` input threw `ERR_INVALID_FILE_URL_HOST` with no context on Linux/macOS, crashing config normalization.
`CreateRequireParserPlugin` also bypassed the shared helper with an inline case-sensitive `startsWith("file://")` check — this moves it to `fileUrlToPath` from `lib/util/identifier`, per the REQUIRED rule in AGENTS.md.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes — added a POSIX-gated test in `test/identifier.unittest.js` that asserts `fileUrlToPath("file://hostname/path")` throws with the offending URL in the message.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

Used Claude (AI assistant) to identify both issues via code review, implement the fixes, and write the tests. All changes were verified locally (ESLint, Prettier, cspell hooks passed; unit and integration tests pass).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for file URLs containing non-localhost hostnames.
  * File URL conversion errors now identify the original URL and provide clearer context about the failure.
  * File URL conversions now report errors more consistently, including the underlying cause where available.

* **Tests**
  * Added coverage to verify expected errors for host-based file URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->