### PR TITLE
fix(concatenate-modules): keep a wrapped reference's ASI guard outside its parentheses

### DIFF
--- a/.changeset/017-concatenate-asi-position.md
+++ b/.changeset/017-concatenate-asi-position.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Keep a concatenated CommonJS reference from joining the previous statement.
+Keep a concatenated CommonJS reference a separate statement, guarding it once.

--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -435,6 +435,18 @@ const getUnusedExportExpr = (info, asiSafe) =>
 		: "/* unused export */ undefined";
 
 /**
+ * Parenthesizes a reference that may already carry an ASI guard of its own,
+ * keeping that guard outside the new parentheses — nested it would not parse.
+ * @param {string} reference the reference
+ * @param {boolean | undefined} asiSafe asiSafe
+ * @returns {string} the parenthesized reference
+ */
+const parenthesizeReference = (reference, asiSafe) =>
+	asiSafe === false
+		? `;(${reference.startsWith(";") ? reference.slice(1) : reference})`
+		: `(${reference})`;
+
+/**
  * @param {ModuleGraph} moduleGraph the module graph
  * @param {ModuleInfo} info module info
  * @param {ExportName} exportName exportName
@@ -1002,12 +1014,12 @@ const getFinalName = (
 						? `;(0,${reference})`
 						: `/*#__PURE__*/Object(${reference})`;
 			} else if (binding.info.wrapped) {
-				return asiSafe === false ? `;(${reference})` : `(${reference})`;
+				return parenthesizeReference(reference, asiSafe);
 			}
 		} else if (accessorCall && !asCall) {
 			// without parentheses `new X()` would construct the accessor rather
 			// than what it returns
-			return asiSafe === false ? `;(${reference})` : `(${reference})`;
+			return parenthesizeReference(reference, asiSafe);
 		}
 
 		return reference;

--- a/test/configCases/concatenate-modules/commonjs-wrapped-assignment-asi-position-output-module/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-assignment-asi-position-output-module/__snapshots__/ConfigCacheTest.snap
@@ -1,0 +1,1105 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigCacheTestCases concatenate-modules commonjs-wrapped-assignment-asi-position-output-module commonjs-wrapped-assignment-asi-position-output-module should compile 1`] = `
+"/******/ // The require scope
+/******/ const __webpack_require__ = {};
+/******/ 
+/************************************************************************/
+/******/ /* webpack/runtime/compat get default export */
+/******/ // getDefaultExport function for compatibility with non-harmony modules
+/******/ __webpack_require__.n = (module) => {
+/******/ 	const getter = module && module.__esModule ?
+/******/ 		() => (module['default']) :
+/******/ 		() => (module);
+/******/ 	__webpack_require__.d(getter, { a: getter });
+/******/ 	return getter;
+/******/ };
+/******/ 
+/******/ /* webpack/runtime/concatenation wrap */
+/******/ // wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ // set before the body runs so re-entrant calls (require cycles) observe
+/******/ // the partial exports like Node.js
+/******/ __webpack_require__.cw = (body) => {
+/******/ 	var mod;
+/******/ 	return () => {
+/******/ 		if (body) {
+/******/ 			var fn = body;
+/******/ 			body = 0;
+/******/ 			mod = { exports: {} };
+/******/ 			fn.call(mod.exports, mod, mod.exports);
+/******/ 		}
+/******/ 		return mod.exports;
+/******/ 	};
+/******/ };
+/******/ 
+/******/ /* webpack/runtime/define property getters */
+/******/ // define getter/value functions for harmony exports
+/******/ __webpack_require__.d = (exports, definition) => {
+/******/ 	for(var key in definition) {
+/******/ 		if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 			Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 		}
+/******/ 	}
+/******/ };
+/******/ 
+/******/ /* webpack/runtime/hasOwnProperty shorthand */
+/******/ __webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop));
+/******/ 
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 3 modules ***!
+  \\\\******************************/
+
+// MODULE: ./formats.js
+var formats_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+// exported through a variable, so the exports stay statically unknown: that is
+// what makes the module wrapped and its default import need interop
+const formats = {
+	loose: {
+		value: \\"original\\",
+		count: 1,
+		flag: false,
+		gone: \\"present\\",
+		deep: { leaf: \\"leaf\\" },
+		run: () => \\"ran\\",
+		Ctor: function Ctor() {
+			this.tag = \\"ctor\\";
+		}
+	},
+	strict: {
+		value: \\"original\\",
+		count: 1,
+		flag: false,
+		deep: { leaf: \\"leaf\\" }
+	},
+	named: () => \\"named\\"
+};
+
+module.exports = formats;
+
+});
+
+;// ./formats.js
+formats_namespaceFn();
+
+function formats_default() { return formats_default.c || (formats_default.c = __webpack_require__.n(formats_namespaceFn())); }
+;// ./loose.js
+// javascript/auto: the default import reads through the interop accessor, which
+// carries an ASI guard of its own that must not end up inside the parentheses
+
+
+
+
+function mutate() {
+	const log = []
+
+	{
+		log.push(\\"assign\\")
+	}
+	;((formats_default()()).loose).value = \\"assigned\\"
+
+	{
+		log.push(\\"compound\\")
+	}
+	;((formats_default()()).loose).count += 2
+
+	{
+		log.push(\\"update\\")
+	}
+	;((formats_default()()).loose).count++
+
+	{
+		log.push(\\"computed\\")
+	}
+	;((formats_default()()).loose)[\\"flag\\"] = true
+
+	{
+		log.push(\\"deep\\")
+	}
+	;((formats_default()()).loose).deep.leaf = \\"reassigned\\"
+
+	{
+		log.push(\\"delete\\")
+	}
+	delete ((formats_default()()).loose).gone
+
+	{
+		log.push(\\"typeof\\")
+	}
+	typeof ((formats_default()()).loose).value
+
+	{
+		log.push(\\"void\\")
+	}
+	void ((formats_default()()).loose).value
+
+	{
+		log.push(\\"call\\")
+	}
+	;(formats_default()().loose).run()
+
+	{
+		log.push(\\"new\\")
+	}
+	new ((formats_default()()).loose).Ctor()
+
+	{
+		log.push(\\"named\\")
+	}
+	;(0,formats_namespaceFn().named)()
+
+	{
+		log.push(\\"namespaceCall\\")
+	}
+	;(formats_namespaceFn().named)()
+
+	{
+		log.push(\\"namespace\\")
+	}
+	;(formats_namespaceFn())
+
+	{
+		log.push(\\"default\\")
+	}
+	;(formats_default()())
+
+	return log
+}
+
+function read() {
+	return ((formats_default()()).loose)
+}
+
+;// ./strict.mjs
+// strict ESM: the default import binds to the wrapper accessor directly, so the
+// same shapes take the other interop path into the one wrapped module
+
+
+
+function strict_mutate() {
+	const log = []
+
+	{
+		log.push(\\"assign\\")
+	}
+	;(formats_namespaceFn().strict).value = \\"assigned\\"
+
+	{
+		log.push(\\"compound\\")
+	}
+	;(formats_namespaceFn().strict).count += 2
+
+	{
+		log.push(\\"update\\")
+	}
+	;(formats_namespaceFn().strict).count++
+
+	{
+		log.push(\\"computed\\")
+	}
+	;(formats_namespaceFn().strict)[\\"flag\\"] = true
+
+	{
+		log.push(\\"deep\\")
+	}
+	;(formats_namespaceFn().strict).deep.leaf = \\"reassigned\\"
+
+	{
+		log.push(\\"namespaceAssign\\")
+	}
+	;(formats_namespaceFn().strict).deep.leaf = \\"namespaced\\"
+
+	return log
+}
+
+function strict_read() {
+	return (formats_namespaceFn().strict)
+}
+
+;// ./index.js
+
+
+
+it(\\"should write through an interop default import at a statement start\\", () => {
+	expect(mutate()).toEqual([
+		\\"assign\\",
+		\\"compound\\",
+		\\"update\\",
+		\\"computed\\",
+		\\"deep\\",
+		\\"delete\\",
+		\\"typeof\\",
+		\\"void\\",
+		\\"call\\",
+		\\"new\\",
+		\\"named\\",
+		\\"namespaceCall\\",
+		\\"namespace\\",
+		\\"default\\"
+	]);
+
+	const loose = read();
+
+	expect(loose.value).toBe(\\"assigned\\");
+	expect(loose.count).toBe(4);
+	expect(loose.flag).toBe(true);
+	expect(loose.deep.leaf).toBe(\\"reassigned\\");
+	expect(\\"gone\\" in loose).toBe(false);
+});
+
+it(\\"should write through a strict ESM default import at a statement start\\", () => {
+	expect(strict_mutate()).toEqual([
+		\\"assign\\",
+		\\"compound\\",
+		\\"update\\",
+		\\"computed\\",
+		\\"deep\\",
+		\\"namespaceAssign\\"
+	]);
+
+	const strict = strict_read();
+
+	expect(strict.value).toBe(\\"assigned\\");
+	expect(strict.count).toBe(4);
+	expect(strict.flag).toBe(true);
+	expect(strict.deep.leaf).toBe(\\"namespaced\\");
+});
+
+it(\\"should reach both interop paths of the one wrapped module\\", () => {
+	expect(read()).not.toBe(strict_read());
+	expect(mutate().length).toBeGreaterThan(0);
+	expect(read().count).toBe(7);
+});
+
+"
+`;
+
+exports[`ConfigCacheTestCases concatenate-modules commonjs-wrapped-assignment-asi-position-output-module commonjs-wrapped-assignment-asi-position-output-module should compile 2`] = `
+"/******/ // The require scope
+/******/ const __webpack_require__ = {};
+/******/ 
+/************************************************************************/
+/******/ /* webpack/runtime/compat get default export */
+/******/ // getDefaultExport function for compatibility with non-harmony modules
+/******/ __webpack_require__.n = (module) => {
+/******/ 	const getter = module && module.__esModule ?
+/******/ 		() => (module['default']) :
+/******/ 		() => (module);
+/******/ 	__webpack_require__.d(getter, { a: getter });
+/******/ 	return getter;
+/******/ };
+/******/ 
+/******/ /* webpack/runtime/concatenation wrap */
+/******/ // wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ // set before the body runs so re-entrant calls (require cycles) observe
+/******/ // the partial exports like Node.js
+/******/ __webpack_require__.cw = (body) => {
+/******/ 	var mod;
+/******/ 	return () => {
+/******/ 		if (body) {
+/******/ 			var fn = body;
+/******/ 			body = 0;
+/******/ 			mod = { exports: {} };
+/******/ 			fn.call(mod.exports, mod, mod.exports);
+/******/ 		}
+/******/ 		return mod.exports;
+/******/ 	};
+/******/ };
+/******/ 
+/******/ /* webpack/runtime/define property getters */
+/******/ // define getter/value functions for harmony exports
+/******/ __webpack_require__.d = (exports, definition) => {
+/******/ 	for(var key in definition) {
+/******/ 		if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 			Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 		}
+/******/ 	}
+/******/ };
+/******/ 
+/******/ /* webpack/runtime/hasOwnProperty shorthand */
+/******/ __webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop));
+/******/ 
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 3 modules ***!
+  \\\\******************************/
+
+// MODULE: ./formats.js
+var formats_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+// exported through a variable, so the exports stay statically unknown: that is
+// what makes the module wrapped and its default import need interop
+const formats = {
+	loose: {
+		value: \\"original\\",
+		count: 1,
+		flag: false,
+		gone: \\"present\\",
+		deep: { leaf: \\"leaf\\" },
+		run: () => \\"ran\\",
+		Ctor: function Ctor() {
+			this.tag = \\"ctor\\";
+		}
+	},
+	strict: {
+		value: \\"original\\",
+		count: 1,
+		flag: false,
+		deep: { leaf: \\"leaf\\" }
+	},
+	named: () => \\"named\\"
+};
+
+module.exports = formats;
+
+});
+
+;// ./formats.js
+formats_namespaceFn();
+
+function formats_default() { return formats_default.c || (formats_default.c = __webpack_require__.n(formats_namespaceFn())); }
+;// ./loose.js
+// javascript/auto: the default import reads through the interop accessor, which
+// carries an ASI guard of its own that must not end up inside the parentheses
+
+
+
+
+function mutate() {
+	const log = []
+
+	{
+		log.push(\\"assign\\")
+	}
+	;((formats_default()()).loose).value = \\"assigned\\"
+
+	{
+		log.push(\\"compound\\")
+	}
+	;((formats_default()()).loose).count += 2
+
+	{
+		log.push(\\"update\\")
+	}
+	;((formats_default()()).loose).count++
+
+	{
+		log.push(\\"computed\\")
+	}
+	;((formats_default()()).loose)[\\"flag\\"] = true
+
+	{
+		log.push(\\"deep\\")
+	}
+	;((formats_default()()).loose).deep.leaf = \\"reassigned\\"
+
+	{
+		log.push(\\"delete\\")
+	}
+	delete ((formats_default()()).loose).gone
+
+	{
+		log.push(\\"typeof\\")
+	}
+	typeof ((formats_default()()).loose).value
+
+	{
+		log.push(\\"void\\")
+	}
+	void ((formats_default()()).loose).value
+
+	{
+		log.push(\\"call\\")
+	}
+	;(formats_default()().loose).run()
+
+	{
+		log.push(\\"new\\")
+	}
+	new ((formats_default()()).loose).Ctor()
+
+	{
+		log.push(\\"named\\")
+	}
+	;(0,formats_namespaceFn().named)()
+
+	{
+		log.push(\\"namespaceCall\\")
+	}
+	;(formats_namespaceFn().named)()
+
+	{
+		log.push(\\"namespace\\")
+	}
+	;(formats_namespaceFn())
+
+	{
+		log.push(\\"default\\")
+	}
+	;(formats_default()())
+
+	return log
+}
+
+function read() {
+	return ((formats_default()()).loose)
+}
+
+;// ./strict.mjs
+// strict ESM: the default import binds to the wrapper accessor directly, so the
+// same shapes take the other interop path into the one wrapped module
+
+
+
+function strict_mutate() {
+	const log = []
+
+	{
+		log.push(\\"assign\\")
+	}
+	;(formats_namespaceFn().strict).value = \\"assigned\\"
+
+	{
+		log.push(\\"compound\\")
+	}
+	;(formats_namespaceFn().strict).count += 2
+
+	{
+		log.push(\\"update\\")
+	}
+	;(formats_namespaceFn().strict).count++
+
+	{
+		log.push(\\"computed\\")
+	}
+	;(formats_namespaceFn().strict)[\\"flag\\"] = true
+
+	{
+		log.push(\\"deep\\")
+	}
+	;(formats_namespaceFn().strict).deep.leaf = \\"reassigned\\"
+
+	{
+		log.push(\\"namespaceAssign\\")
+	}
+	;(formats_namespaceFn().strict).deep.leaf = \\"namespaced\\"
+
+	return log
+}
+
+function strict_read() {
+	return (formats_namespaceFn().strict)
+}
+
+;// ./index.js
+
+
+
+it(\\"should write through an interop default import at a statement start\\", () => {
+	expect(mutate()).toEqual([
+		\\"assign\\",
+		\\"compound\\",
+		\\"update\\",
+		\\"computed\\",
+		\\"deep\\",
+		\\"delete\\",
+		\\"typeof\\",
+		\\"void\\",
+		\\"call\\",
+		\\"new\\",
+		\\"named\\",
+		\\"namespaceCall\\",
+		\\"namespace\\",
+		\\"default\\"
+	]);
+
+	const loose = read();
+
+	expect(loose.value).toBe(\\"assigned\\");
+	expect(loose.count).toBe(4);
+	expect(loose.flag).toBe(true);
+	expect(loose.deep.leaf).toBe(\\"reassigned\\");
+	expect(\\"gone\\" in loose).toBe(false);
+});
+
+it(\\"should write through a strict ESM default import at a statement start\\", () => {
+	expect(strict_mutate()).toEqual([
+		\\"assign\\",
+		\\"compound\\",
+		\\"update\\",
+		\\"computed\\",
+		\\"deep\\",
+		\\"namespaceAssign\\"
+	]);
+
+	const strict = strict_read();
+
+	expect(strict.value).toBe(\\"assigned\\");
+	expect(strict.count).toBe(4);
+	expect(strict.flag).toBe(true);
+	expect(strict.deep.leaf).toBe(\\"namespaced\\");
+});
+
+it(\\"should reach both interop paths of the one wrapped module\\", () => {
+	expect(read()).not.toBe(strict_read());
+	expect(mutate().length).toBeGreaterThan(0);
+	expect(read().count).toBe(7);
+});
+
+"
+`;
+
+exports[`ConfigCacheTestCases concatenate-modules commonjs-wrapped-assignment-asi-position-output-module commonjs-wrapped-assignment-asi-position-output-module should pre-compile to fill disk cache (1st) 1`] = `
+"/******/ // The require scope
+/******/ const __webpack_require__ = {};
+/******/ 
+/************************************************************************/
+/******/ /* webpack/runtime/compat get default export */
+/******/ // getDefaultExport function for compatibility with non-harmony modules
+/******/ __webpack_require__.n = (module) => {
+/******/ 	const getter = module && module.__esModule ?
+/******/ 		() => (module['default']) :
+/******/ 		() => (module);
+/******/ 	__webpack_require__.d(getter, { a: getter });
+/******/ 	return getter;
+/******/ };
+/******/ 
+/******/ /* webpack/runtime/concatenation wrap */
+/******/ // wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ // set before the body runs so re-entrant calls (require cycles) observe
+/******/ // the partial exports like Node.js
+/******/ __webpack_require__.cw = (body) => {
+/******/ 	var mod;
+/******/ 	return () => {
+/******/ 		if (body) {
+/******/ 			var fn = body;
+/******/ 			body = 0;
+/******/ 			mod = { exports: {} };
+/******/ 			fn.call(mod.exports, mod, mod.exports);
+/******/ 		}
+/******/ 		return mod.exports;
+/******/ 	};
+/******/ };
+/******/ 
+/******/ /* webpack/runtime/define property getters */
+/******/ // define getter/value functions for harmony exports
+/******/ __webpack_require__.d = (exports, definition) => {
+/******/ 	for(var key in definition) {
+/******/ 		if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 			Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 		}
+/******/ 	}
+/******/ };
+/******/ 
+/******/ /* webpack/runtime/hasOwnProperty shorthand */
+/******/ __webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop));
+/******/ 
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 3 modules ***!
+  \\\\******************************/
+
+// MODULE: ./formats.js
+var formats_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+// exported through a variable, so the exports stay statically unknown: that is
+// what makes the module wrapped and its default import need interop
+const formats = {
+	loose: {
+		value: \\"original\\",
+		count: 1,
+		flag: false,
+		gone: \\"present\\",
+		deep: { leaf: \\"leaf\\" },
+		run: () => \\"ran\\",
+		Ctor: function Ctor() {
+			this.tag = \\"ctor\\";
+		}
+	},
+	strict: {
+		value: \\"original\\",
+		count: 1,
+		flag: false,
+		deep: { leaf: \\"leaf\\" }
+	},
+	named: () => \\"named\\"
+};
+
+module.exports = formats;
+
+});
+
+;// ./formats.js
+formats_namespaceFn();
+
+function formats_default() { return formats_default.c || (formats_default.c = __webpack_require__.n(formats_namespaceFn())); }
+;// ./loose.js
+// javascript/auto: the default import reads through the interop accessor, which
+// carries an ASI guard of its own that must not end up inside the parentheses
+
+
+
+
+function mutate() {
+	const log = []
+
+	{
+		log.push(\\"assign\\")
+	}
+	;((formats_default()()).loose).value = \\"assigned\\"
+
+	{
+		log.push(\\"compound\\")
+	}
+	;((formats_default()()).loose).count += 2
+
+	{
+		log.push(\\"update\\")
+	}
+	;((formats_default()()).loose).count++
+
+	{
+		log.push(\\"computed\\")
+	}
+	;((formats_default()()).loose)[\\"flag\\"] = true
+
+	{
+		log.push(\\"deep\\")
+	}
+	;((formats_default()()).loose).deep.leaf = \\"reassigned\\"
+
+	{
+		log.push(\\"delete\\")
+	}
+	delete ((formats_default()()).loose).gone
+
+	{
+		log.push(\\"typeof\\")
+	}
+	typeof ((formats_default()()).loose).value
+
+	{
+		log.push(\\"void\\")
+	}
+	void ((formats_default()()).loose).value
+
+	{
+		log.push(\\"call\\")
+	}
+	;(formats_default()().loose).run()
+
+	{
+		log.push(\\"new\\")
+	}
+	new ((formats_default()()).loose).Ctor()
+
+	{
+		log.push(\\"named\\")
+	}
+	;(0,formats_namespaceFn().named)()
+
+	{
+		log.push(\\"namespaceCall\\")
+	}
+	;(formats_namespaceFn().named)()
+
+	{
+		log.push(\\"namespace\\")
+	}
+	;(formats_namespaceFn())
+
+	{
+		log.push(\\"default\\")
+	}
+	;(formats_default()())
+
+	return log
+}
+
+function read() {
+	return ((formats_default()()).loose)
+}
+
+;// ./strict.mjs
+// strict ESM: the default import binds to the wrapper accessor directly, so the
+// same shapes take the other interop path into the one wrapped module
+
+
+
+function strict_mutate() {
+	const log = []
+
+	{
+		log.push(\\"assign\\")
+	}
+	;(formats_namespaceFn().strict).value = \\"assigned\\"
+
+	{
+		log.push(\\"compound\\")
+	}
+	;(formats_namespaceFn().strict).count += 2
+
+	{
+		log.push(\\"update\\")
+	}
+	;(formats_namespaceFn().strict).count++
+
+	{
+		log.push(\\"computed\\")
+	}
+	;(formats_namespaceFn().strict)[\\"flag\\"] = true
+
+	{
+		log.push(\\"deep\\")
+	}
+	;(formats_namespaceFn().strict).deep.leaf = \\"reassigned\\"
+
+	{
+		log.push(\\"namespaceAssign\\")
+	}
+	;(formats_namespaceFn().strict).deep.leaf = \\"namespaced\\"
+
+	return log
+}
+
+function strict_read() {
+	return (formats_namespaceFn().strict)
+}
+
+;// ./index.js
+
+
+
+it(\\"should write through an interop default import at a statement start\\", () => {
+	expect(mutate()).toEqual([
+		\\"assign\\",
+		\\"compound\\",
+		\\"update\\",
+		\\"computed\\",
+		\\"deep\\",
+		\\"delete\\",
+		\\"typeof\\",
+		\\"void\\",
+		\\"call\\",
+		\\"new\\",
+		\\"named\\",
+		\\"namespaceCall\\",
+		\\"namespace\\",
+		\\"default\\"
+	]);
+
+	const loose = read();
+
+	expect(loose.value).toBe(\\"assigned\\");
+	expect(loose.count).toBe(4);
+	expect(loose.flag).toBe(true);
+	expect(loose.deep.leaf).toBe(\\"reassigned\\");
+	expect(\\"gone\\" in loose).toBe(false);
+});
+
+it(\\"should write through a strict ESM default import at a statement start\\", () => {
+	expect(strict_mutate()).toEqual([
+		\\"assign\\",
+		\\"compound\\",
+		\\"update\\",
+		\\"computed\\",
+		\\"deep\\",
+		\\"namespaceAssign\\"
+	]);
+
+	const strict = strict_read();
+
+	expect(strict.value).toBe(\\"assigned\\");
+	expect(strict.count).toBe(4);
+	expect(strict.flag).toBe(true);
+	expect(strict.deep.leaf).toBe(\\"namespaced\\");
+});
+
+it(\\"should reach both interop paths of the one wrapped module\\", () => {
+	expect(read()).not.toBe(strict_read());
+	expect(mutate().length).toBeGreaterThan(0);
+	expect(read().count).toBe(7);
+});
+
+"
+`;
+
+exports[`ConfigCacheTestCases concatenate-modules commonjs-wrapped-assignment-asi-position-output-module commonjs-wrapped-assignment-asi-position-output-module should pre-compile to fill disk cache (2nd) 1`] = `
+"/******/ // The require scope
+/******/ const __webpack_require__ = {};
+/******/ 
+/************************************************************************/
+/******/ /* webpack/runtime/compat get default export */
+/******/ // getDefaultExport function for compatibility with non-harmony modules
+/******/ __webpack_require__.n = (module) => {
+/******/ 	const getter = module && module.__esModule ?
+/******/ 		() => (module['default']) :
+/******/ 		() => (module);
+/******/ 	__webpack_require__.d(getter, { a: getter });
+/******/ 	return getter;
+/******/ };
+/******/ 
+/******/ /* webpack/runtime/concatenation wrap */
+/******/ // wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ // set before the body runs so re-entrant calls (require cycles) observe
+/******/ // the partial exports like Node.js
+/******/ __webpack_require__.cw = (body) => {
+/******/ 	var mod;
+/******/ 	return () => {
+/******/ 		if (body) {
+/******/ 			var fn = body;
+/******/ 			body = 0;
+/******/ 			mod = { exports: {} };
+/******/ 			fn.call(mod.exports, mod, mod.exports);
+/******/ 		}
+/******/ 		return mod.exports;
+/******/ 	};
+/******/ };
+/******/ 
+/******/ /* webpack/runtime/define property getters */
+/******/ // define getter/value functions for harmony exports
+/******/ __webpack_require__.d = (exports, definition) => {
+/******/ 	for(var key in definition) {
+/******/ 		if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 			Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 		}
+/******/ 	}
+/******/ };
+/******/ 
+/******/ /* webpack/runtime/hasOwnProperty shorthand */
+/******/ __webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop));
+/******/ 
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 3 modules ***!
+  \\\\******************************/
+
+// MODULE: ./formats.js
+var formats_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+// exported through a variable, so the exports stay statically unknown: that is
+// what makes the module wrapped and its default import need interop
+const formats = {
+	loose: {
+		value: \\"original\\",
+		count: 1,
+		flag: false,
+		gone: \\"present\\",
+		deep: { leaf: \\"leaf\\" },
+		run: () => \\"ran\\",
+		Ctor: function Ctor() {
+			this.tag = \\"ctor\\";
+		}
+	},
+	strict: {
+		value: \\"original\\",
+		count: 1,
+		flag: false,
+		deep: { leaf: \\"leaf\\" }
+	},
+	named: () => \\"named\\"
+};
+
+module.exports = formats;
+
+});
+
+;// ./formats.js
+formats_namespaceFn();
+
+function formats_default() { return formats_default.c || (formats_default.c = __webpack_require__.n(formats_namespaceFn())); }
+;// ./loose.js
+// javascript/auto: the default import reads through the interop accessor, which
+// carries an ASI guard of its own that must not end up inside the parentheses
+
+
+
+
+function mutate() {
+	const log = []
+
+	{
+		log.push(\\"assign\\")
+	}
+	;((formats_default()()).loose).value = \\"assigned\\"
+
+	{
+		log.push(\\"compound\\")
+	}
+	;((formats_default()()).loose).count += 2
+
+	{
+		log.push(\\"update\\")
+	}
+	;((formats_default()()).loose).count++
+
+	{
+		log.push(\\"computed\\")
+	}
+	;((formats_default()()).loose)[\\"flag\\"] = true
+
+	{
+		log.push(\\"deep\\")
+	}
+	;((formats_default()()).loose).deep.leaf = \\"reassigned\\"
+
+	{
+		log.push(\\"delete\\")
+	}
+	delete ((formats_default()()).loose).gone
+
+	{
+		log.push(\\"typeof\\")
+	}
+	typeof ((formats_default()()).loose).value
+
+	{
+		log.push(\\"void\\")
+	}
+	void ((formats_default()()).loose).value
+
+	{
+		log.push(\\"call\\")
+	}
+	;(formats_default()().loose).run()
+
+	{
+		log.push(\\"new\\")
+	}
+	new ((formats_default()()).loose).Ctor()
+
+	{
+		log.push(\\"named\\")
+	}
+	;(0,formats_namespaceFn().named)()
+
+	{
+		log.push(\\"namespaceCall\\")
+	}
+	;(formats_namespaceFn().named)()
+
+	{
+		log.push(\\"namespace\\")
+	}
+	;(formats_namespaceFn())
+
+	{
+		log.push(\\"default\\")
+	}
+	;(formats_default()())
+
+	return log
+}
+
+function read() {
+	return ((formats_default()()).loose)
+}
+
+;// ./strict.mjs
+// strict ESM: the default import binds to the wrapper accessor directly, so the
+// same shapes take the other interop path into the one wrapped module
+
+
+
+function strict_mutate() {
+	const log = []
+
+	{
+		log.push(\\"assign\\")
+	}
+	;(formats_namespaceFn().strict).value = \\"assigned\\"
+
+	{
+		log.push(\\"compound\\")
+	}
+	;(formats_namespaceFn().strict).count += 2
+
+	{
+		log.push(\\"update\\")
+	}
+	;(formats_namespaceFn().strict).count++
+
+	{
+		log.push(\\"computed\\")
+	}
+	;(formats_namespaceFn().strict)[\\"flag\\"] = true
+
+	{
+		log.push(\\"deep\\")
+	}
+	;(formats_namespaceFn().strict).deep.leaf = \\"reassigned\\"
+
+	{
+		log.push(\\"namespaceAssign\\")
+	}
+	;(formats_namespaceFn().strict).deep.leaf = \\"namespaced\\"
+
+	return log
+}
+
+function strict_read() {
+	return (formats_namespaceFn().strict)
+}
+
+;// ./index.js
+
+
+
+it(\\"should write through an interop default import at a statement start\\", () => {
+	expect(mutate()).toEqual([
+		\\"assign\\",
+		\\"compound\\",
+		\\"update\\",
+		\\"computed\\",
+		\\"deep\\",
+		\\"delete\\",
+		\\"typeof\\",
+		\\"void\\",
+		\\"call\\",
+		\\"new\\",
+		\\"named\\",
+		\\"namespaceCall\\",
+		\\"namespace\\",
+		\\"default\\"
+	]);
+
+	const loose = read();
+
+	expect(loose.value).toBe(\\"assigned\\");
+	expect(loose.count).toBe(4);
+	expect(loose.flag).toBe(true);
+	expect(loose.deep.leaf).toBe(\\"reassigned\\");
+	expect(\\"gone\\" in loose).toBe(false);
+});
+
+it(\\"should write through a strict ESM default import at a statement start\\", () => {
+	expect(strict_mutate()).toEqual([
+		\\"assign\\",
+		\\"compound\\",
+		\\"update\\",
+		\\"computed\\",
+		\\"deep\\",
+		\\"namespaceAssign\\"
+	]);
+
+	const strict = strict_read();
+
+	expect(strict.value).toBe(\\"assigned\\");
+	expect(strict.count).toBe(4);
+	expect(strict.flag).toBe(true);
+	expect(strict.deep.leaf).toBe(\\"namespaced\\");
+});
+
+it(\\"should reach both interop paths of the one wrapped module\\", () => {
+	expect(read()).not.toBe(strict_read());
+	expect(mutate().length).toBeGreaterThan(0);
+	expect(read().count).toBe(7);
+});
+
+"
+`;

--- a/test/configCases/concatenate-modules/commonjs-wrapped-assignment-asi-position-output-module/__snapshots__/ConfigTest.snap
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-assignment-asi-position-output-module/__snapshots__/ConfigTest.snap
@@ -1,0 +1,277 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigTestCases concatenate-modules commonjs-wrapped-assignment-asi-position-output-module commonjs-wrapped-assignment-asi-position-output-module should compile 1`] = `
+"/******/ // The require scope
+/******/ const __webpack_require__ = {};
+/******/ 
+/************************************************************************/
+/******/ /* webpack/runtime/compat get default export */
+/******/ // getDefaultExport function for compatibility with non-harmony modules
+/******/ __webpack_require__.n = (module) => {
+/******/ 	const getter = module && module.__esModule ?
+/******/ 		() => (module['default']) :
+/******/ 		() => (module);
+/******/ 	__webpack_require__.d(getter, { a: getter });
+/******/ 	return getter;
+/******/ };
+/******/ 
+/******/ /* webpack/runtime/concatenation wrap */
+/******/ // wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ // set before the body runs so re-entrant calls (require cycles) observe
+/******/ // the partial exports like Node.js
+/******/ __webpack_require__.cw = (body) => {
+/******/ 	var mod;
+/******/ 	return () => {
+/******/ 		if (body) {
+/******/ 			var fn = body;
+/******/ 			body = 0;
+/******/ 			mod = { exports: {} };
+/******/ 			fn.call(mod.exports, mod, mod.exports);
+/******/ 		}
+/******/ 		return mod.exports;
+/******/ 	};
+/******/ };
+/******/ 
+/******/ /* webpack/runtime/define property getters */
+/******/ // define getter/value functions for harmony exports
+/******/ __webpack_require__.d = (exports, definition) => {
+/******/ 	for(var key in definition) {
+/******/ 		if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 			Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 		}
+/******/ 	}
+/******/ };
+/******/ 
+/******/ /* webpack/runtime/hasOwnProperty shorthand */
+/******/ __webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop));
+/******/ 
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 3 modules ***!
+  \\\\******************************/
+
+// MODULE: ./formats.js
+var formats_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+// exported through a variable, so the exports stay statically unknown: that is
+// what makes the module wrapped and its default import need interop
+const formats = {
+	loose: {
+		value: \\"original\\",
+		count: 1,
+		flag: false,
+		gone: \\"present\\",
+		deep: { leaf: \\"leaf\\" },
+		run: () => \\"ran\\",
+		Ctor: function Ctor() {
+			this.tag = \\"ctor\\";
+		}
+	},
+	strict: {
+		value: \\"original\\",
+		count: 1,
+		flag: false,
+		deep: { leaf: \\"leaf\\" }
+	},
+	named: () => \\"named\\"
+};
+
+module.exports = formats;
+
+});
+
+;// ./formats.js
+formats_namespaceFn();
+
+function formats_default() { return formats_default.c || (formats_default.c = __webpack_require__.n(formats_namespaceFn())); }
+;// ./loose.js
+// javascript/auto: the default import reads through the interop accessor, which
+// carries an ASI guard of its own that must not end up inside the parentheses
+
+
+
+
+function mutate() {
+	const log = []
+
+	{
+		log.push(\\"assign\\")
+	}
+	;((formats_default()()).loose).value = \\"assigned\\"
+
+	{
+		log.push(\\"compound\\")
+	}
+	;((formats_default()()).loose).count += 2
+
+	{
+		log.push(\\"update\\")
+	}
+	;((formats_default()()).loose).count++
+
+	{
+		log.push(\\"computed\\")
+	}
+	;((formats_default()()).loose)[\\"flag\\"] = true
+
+	{
+		log.push(\\"deep\\")
+	}
+	;((formats_default()()).loose).deep.leaf = \\"reassigned\\"
+
+	{
+		log.push(\\"delete\\")
+	}
+	delete ((formats_default()()).loose).gone
+
+	{
+		log.push(\\"typeof\\")
+	}
+	typeof ((formats_default()()).loose).value
+
+	{
+		log.push(\\"void\\")
+	}
+	void ((formats_default()()).loose).value
+
+	{
+		log.push(\\"call\\")
+	}
+	;(formats_default()().loose).run()
+
+	{
+		log.push(\\"new\\")
+	}
+	new ((formats_default()()).loose).Ctor()
+
+	{
+		log.push(\\"named\\")
+	}
+	;(0,formats_namespaceFn().named)()
+
+	{
+		log.push(\\"namespaceCall\\")
+	}
+	;(formats_namespaceFn().named)()
+
+	{
+		log.push(\\"namespace\\")
+	}
+	;(formats_namespaceFn())
+
+	{
+		log.push(\\"default\\")
+	}
+	;(formats_default()())
+
+	return log
+}
+
+function read() {
+	return ((formats_default()()).loose)
+}
+
+;// ./strict.mjs
+// strict ESM: the default import binds to the wrapper accessor directly, so the
+// same shapes take the other interop path into the one wrapped module
+
+
+
+function strict_mutate() {
+	const log = []
+
+	{
+		log.push(\\"assign\\")
+	}
+	;(formats_namespaceFn().strict).value = \\"assigned\\"
+
+	{
+		log.push(\\"compound\\")
+	}
+	;(formats_namespaceFn().strict).count += 2
+
+	{
+		log.push(\\"update\\")
+	}
+	;(formats_namespaceFn().strict).count++
+
+	{
+		log.push(\\"computed\\")
+	}
+	;(formats_namespaceFn().strict)[\\"flag\\"] = true
+
+	{
+		log.push(\\"deep\\")
+	}
+	;(formats_namespaceFn().strict).deep.leaf = \\"reassigned\\"
+
+	{
+		log.push(\\"namespaceAssign\\")
+	}
+	;(formats_namespaceFn().strict).deep.leaf = \\"namespaced\\"
+
+	return log
+}
+
+function strict_read() {
+	return (formats_namespaceFn().strict)
+}
+
+;// ./index.js
+
+
+
+it(\\"should write through an interop default import at a statement start\\", () => {
+	expect(mutate()).toEqual([
+		\\"assign\\",
+		\\"compound\\",
+		\\"update\\",
+		\\"computed\\",
+		\\"deep\\",
+		\\"delete\\",
+		\\"typeof\\",
+		\\"void\\",
+		\\"call\\",
+		\\"new\\",
+		\\"named\\",
+		\\"namespaceCall\\",
+		\\"namespace\\",
+		\\"default\\"
+	]);
+
+	const loose = read();
+
+	expect(loose.value).toBe(\\"assigned\\");
+	expect(loose.count).toBe(4);
+	expect(loose.flag).toBe(true);
+	expect(loose.deep.leaf).toBe(\\"reassigned\\");
+	expect(\\"gone\\" in loose).toBe(false);
+});
+
+it(\\"should write through a strict ESM default import at a statement start\\", () => {
+	expect(strict_mutate()).toEqual([
+		\\"assign\\",
+		\\"compound\\",
+		\\"update\\",
+		\\"computed\\",
+		\\"deep\\",
+		\\"namespaceAssign\\"
+	]);
+
+	const strict = strict_read();
+
+	expect(strict.value).toBe(\\"assigned\\");
+	expect(strict.count).toBe(4);
+	expect(strict.flag).toBe(true);
+	expect(strict.deep.leaf).toBe(\\"namespaced\\");
+});
+
+it(\\"should reach both interop paths of the one wrapped module\\", () => {
+	expect(read()).not.toBe(strict_read());
+	expect(mutate().length).toBeGreaterThan(0);
+	expect(read().count).toBe(7);
+});
+
+"
+`;

--- a/test/configCases/concatenate-modules/commonjs-wrapped-assignment-asi-position-output-module/formats.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-assignment-asi-position-output-module/formats.js
@@ -1,0 +1,26 @@
+"use strict";
+
+// exported through a variable, so the exports stay statically unknown: that is
+// what makes the module wrapped and its default import need interop
+const formats = {
+	loose: {
+		value: "original",
+		count: 1,
+		flag: false,
+		gone: "present",
+		deep: { leaf: "leaf" },
+		run: () => "ran",
+		Ctor: function Ctor() {
+			this.tag = "ctor";
+		}
+	},
+	strict: {
+		value: "original",
+		count: 1,
+		flag: false,
+		deep: { leaf: "leaf" }
+	},
+	named: () => "named"
+};
+
+module.exports = formats;

--- a/test/configCases/concatenate-modules/commonjs-wrapped-assignment-asi-position-output-module/index.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-assignment-asi-position-output-module/index.js
@@ -1,0 +1,53 @@
+import { mutate as mutateLoose, read as readLoose } from "./loose";
+import { mutate as mutateStrict, read as readStrict } from "./strict.mjs";
+
+it("should write through an interop default import at a statement start", () => {
+	expect(mutateLoose()).toEqual([
+		"assign",
+		"compound",
+		"update",
+		"computed",
+		"deep",
+		"delete",
+		"typeof",
+		"void",
+		"call",
+		"new",
+		"named",
+		"namespaceCall",
+		"namespace",
+		"default"
+	]);
+
+	const loose = readLoose();
+
+	expect(loose.value).toBe("assigned");
+	expect(loose.count).toBe(4);
+	expect(loose.flag).toBe(true);
+	expect(loose.deep.leaf).toBe("reassigned");
+	expect("gone" in loose).toBe(false);
+});
+
+it("should write through a strict ESM default import at a statement start", () => {
+	expect(mutateStrict()).toEqual([
+		"assign",
+		"compound",
+		"update",
+		"computed",
+		"deep",
+		"namespaceAssign"
+	]);
+
+	const strict = readStrict();
+
+	expect(strict.value).toBe("assigned");
+	expect(strict.count).toBe(4);
+	expect(strict.flag).toBe(true);
+	expect(strict.deep.leaf).toBe("namespaced");
+});
+
+it("should reach both interop paths of the one wrapped module", () => {
+	expect(readLoose()).not.toBe(readStrict());
+	expect(mutateLoose().length).toBeGreaterThan(0);
+	expect(readLoose().count).toBe(7);
+});

--- a/test/configCases/concatenate-modules/commonjs-wrapped-assignment-asi-position-output-module/loose.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-assignment-asi-position-output-module/loose.js
@@ -1,0 +1,85 @@
+// javascript/auto: the default import reads through the interop accessor, which
+// carries an ASI guard of its own that must not end up inside the parentheses
+import formats from "./formats"
+import { named } from "./formats"
+import * as namespace from "./formats"
+
+export function mutate() {
+	const log = []
+
+	{
+		log.push("assign")
+	}
+	formats.loose.value = "assigned"
+
+	{
+		log.push("compound")
+	}
+	formats.loose.count += 2
+
+	{
+		log.push("update")
+	}
+	formats.loose.count++
+
+	{
+		log.push("computed")
+	}
+	formats.loose["flag"] = true
+
+	{
+		log.push("deep")
+	}
+	formats.loose.deep.leaf = "reassigned"
+
+	{
+		log.push("delete")
+	}
+	delete formats.loose.gone
+
+	{
+		log.push("typeof")
+	}
+	typeof formats.loose.value
+
+	{
+		log.push("void")
+	}
+	void formats.loose.value
+
+	{
+		log.push("call")
+	}
+	formats.loose.run()
+
+	{
+		log.push("new")
+	}
+	new formats.loose.Ctor()
+
+	{
+		log.push("named")
+	}
+	named()
+
+	{
+		log.push("namespaceCall")
+	}
+	namespace.named()
+
+	{
+		log.push("namespace")
+	}
+	namespace
+
+	{
+		log.push("default")
+	}
+	formats
+
+	return log
+}
+
+export function read() {
+	return formats.loose
+}

--- a/test/configCases/concatenate-modules/commonjs-wrapped-assignment-asi-position-output-module/strict.mjs
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-assignment-asi-position-output-module/strict.mjs
@@ -1,0 +1,44 @@
+// strict ESM: the default import binds to the wrapper accessor directly, so the
+// same shapes take the other interop path into the one wrapped module
+import formats from "./formats.js"
+import * as namespace from "./formats.js"
+
+export function mutate() {
+	const log = []
+
+	{
+		log.push("assign")
+	}
+	formats.strict.value = "assigned"
+
+	{
+		log.push("compound")
+	}
+	formats.strict.count += 2
+
+	{
+		log.push("update")
+	}
+	formats.strict.count++
+
+	{
+		log.push("computed")
+	}
+	formats.strict["flag"] = true
+
+	{
+		log.push("deep")
+	}
+	formats.strict.deep.leaf = "reassigned"
+
+	{
+		log.push("namespaceAssign")
+	}
+	namespace.default.strict.deep.leaf = "namespaced"
+
+	return log
+}
+
+export function read() {
+	return formats.strict
+}

--- a/test/configCases/concatenate-modules/commonjs-wrapped-assignment-asi-position-output-module/webpack.config.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-assignment-asi-position-output-module/webpack.config.js
@@ -1,0 +1,31 @@
+"use strict";
+
+const PLUGIN_NAME = "SnapshotBundlePlugin";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	output: { module: true },
+	mode: "production",
+	target: "node",
+	devtool: false,
+	optimization: {
+		concatenateModules: { commonjs: true },
+		minimize: false,
+		usedExports: true,
+		moduleIds: "named",
+		chunkIds: "named"
+	},
+	plugins: [
+		/**
+		 * What this case checks is printed code, so review the bundle as a whole.
+		 * @param {import("../../../../").Compiler} compiler compiler
+		 */
+		(compiler) => {
+			compiler.hooks.compilation.tap(PLUGIN_NAME, (compilation) => {
+				compilation.hooks.afterProcessAssets.tap(PLUGIN_NAME, (assets) => {
+					expect(assets["bundle0.mjs"].source()).toMatchSnapshot();
+				});
+			});
+		}
+	]
+};

--- a/test/configCases/concatenate-modules/commonjs-wrapped-assignment-asi-position-require/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-assignment-asi-position-require/__snapshots__/ConfigCacheTest.snap
@@ -1,0 +1,509 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigCacheTestCases concatenate-modules commonjs-wrapped-assignment-asi-position-require commonjs-wrapped-assignment-asi-position-require should compile 1`] = `
+"/******/ (() => { // webpackBootstrap
+/******/ 	\\"use strict\\";
+/******/ 	// The require scope
+/******/ 	const __webpack_require__ = {};
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/concatenation wrap */
+/******/ 	// wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ 	// set before the body runs so re-entrant calls (require cycles) observe
+/******/ 	// the partial exports like Node.js
+/******/ 	__webpack_require__.cw = (body) => {
+/******/ 		var mod;
+/******/ 		return () => {
+/******/ 			if (body) {
+/******/ 				var fn = body;
+/******/ 				body = 0;
+/******/ 				mod = { exports: {} };
+/******/ 				fn.call(mod.exports, mod, mod.exports);
+/******/ 			}
+/******/ 			return mod.exports;
+/******/ 		};
+/******/ 	};
+/******/ 	
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 2 modules ***!
+  \\\\******************************/
+
+// MODULE: ./body.js
+var body_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+// semicolon-free: every require below starts a statement where ASI would join
+// the block above it, and each one writes through a parenthesized member access
+const log = []
+
+{
+	log.push(\\"assign\\")
+}
+;(store_namespaceFn().nested).value = \\"assigned\\"
+
+{
+	log.push(\\"compound\\")
+}
+;(store_namespaceFn().nested).count += 2
+
+{
+	log.push(\\"update\\")
+}
+;(store_namespaceFn().nested).count++
+
+{
+	log.push(\\"computed\\")
+}
+;(store_namespaceFn().nested)[\\"flag\\"] = true
+
+{
+	log.push(\\"deep\\")
+}
+;(store_namespaceFn().nested).deep.leaf = \\"reassigned\\"
+
+{
+	log.push(\\"delete\\")
+}
+delete (store_namespaceFn().nested).gone
+
+{
+	log.push(\\"read\\")
+}
+;(store_namespaceFn().nested).value
+
+module.exports.z = () => log
+module.exports.L = () => (store_namespaceFn().nested)
+
+});
+
+// MODULE: ./store.js
+var store_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+// exported through a variable, so the exports stay statically unknown and every
+// reader below reaches the module through its wrapper accessor
+const store = {
+	nested: {
+		value: \\"original\\",
+		count: 1,
+		flag: false,
+		gone: \\"present\\",
+		deep: { leaf: \\"leaf\\" }
+	}
+};
+
+module.exports = store;
+
+});
+
+;// ./body.js
+body_namespaceFn();
+
+;// ./index.js
+
+
+it(\\"should write through a required wrapped module at a statement start\\", () => {
+	expect((0,body_namespaceFn().z)()).toEqual([
+		\\"assign\\",
+		\\"compound\\",
+		\\"update\\",
+		\\"computed\\",
+		\\"deep\\",
+		\\"delete\\",
+		\\"read\\"
+	]);
+
+	const nested = (0,body_namespaceFn().L)();
+
+	expect(nested.value).toBe(\\"assigned\\");
+	expect(nested.count).toBe(4);
+	expect(nested.flag).toBe(true);
+	expect(nested.deep.leaf).toBe(\\"reassigned\\");
+	expect(\\"gone\\" in nested).toBe(false);
+});
+
+/******/ })()
+;"
+`;
+
+exports[`ConfigCacheTestCases concatenate-modules commonjs-wrapped-assignment-asi-position-require commonjs-wrapped-assignment-asi-position-require should compile 2`] = `
+"/******/ (() => { // webpackBootstrap
+/******/ 	\\"use strict\\";
+/******/ 	// The require scope
+/******/ 	const __webpack_require__ = {};
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/concatenation wrap */
+/******/ 	// wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ 	// set before the body runs so re-entrant calls (require cycles) observe
+/******/ 	// the partial exports like Node.js
+/******/ 	__webpack_require__.cw = (body) => {
+/******/ 		var mod;
+/******/ 		return () => {
+/******/ 			if (body) {
+/******/ 				var fn = body;
+/******/ 				body = 0;
+/******/ 				mod = { exports: {} };
+/******/ 				fn.call(mod.exports, mod, mod.exports);
+/******/ 			}
+/******/ 			return mod.exports;
+/******/ 		};
+/******/ 	};
+/******/ 	
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 2 modules ***!
+  \\\\******************************/
+
+// MODULE: ./body.js
+var body_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+// semicolon-free: every require below starts a statement where ASI would join
+// the block above it, and each one writes through a parenthesized member access
+const log = []
+
+{
+	log.push(\\"assign\\")
+}
+;(store_namespaceFn().nested).value = \\"assigned\\"
+
+{
+	log.push(\\"compound\\")
+}
+;(store_namespaceFn().nested).count += 2
+
+{
+	log.push(\\"update\\")
+}
+;(store_namespaceFn().nested).count++
+
+{
+	log.push(\\"computed\\")
+}
+;(store_namespaceFn().nested)[\\"flag\\"] = true
+
+{
+	log.push(\\"deep\\")
+}
+;(store_namespaceFn().nested).deep.leaf = \\"reassigned\\"
+
+{
+	log.push(\\"delete\\")
+}
+delete (store_namespaceFn().nested).gone
+
+{
+	log.push(\\"read\\")
+}
+;(store_namespaceFn().nested).value
+
+module.exports.z = () => log
+module.exports.L = () => (store_namespaceFn().nested)
+
+});
+
+// MODULE: ./store.js
+var store_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+// exported through a variable, so the exports stay statically unknown and every
+// reader below reaches the module through its wrapper accessor
+const store = {
+	nested: {
+		value: \\"original\\",
+		count: 1,
+		flag: false,
+		gone: \\"present\\",
+		deep: { leaf: \\"leaf\\" }
+	}
+};
+
+module.exports = store;
+
+});
+
+;// ./body.js
+body_namespaceFn();
+
+;// ./index.js
+
+
+it(\\"should write through a required wrapped module at a statement start\\", () => {
+	expect((0,body_namespaceFn().z)()).toEqual([
+		\\"assign\\",
+		\\"compound\\",
+		\\"update\\",
+		\\"computed\\",
+		\\"deep\\",
+		\\"delete\\",
+		\\"read\\"
+	]);
+
+	const nested = (0,body_namespaceFn().L)();
+
+	expect(nested.value).toBe(\\"assigned\\");
+	expect(nested.count).toBe(4);
+	expect(nested.flag).toBe(true);
+	expect(nested.deep.leaf).toBe(\\"reassigned\\");
+	expect(\\"gone\\" in nested).toBe(false);
+});
+
+/******/ })()
+;"
+`;
+
+exports[`ConfigCacheTestCases concatenate-modules commonjs-wrapped-assignment-asi-position-require commonjs-wrapped-assignment-asi-position-require should pre-compile to fill disk cache (1st) 1`] = `
+"/******/ (() => { // webpackBootstrap
+/******/ 	\\"use strict\\";
+/******/ 	// The require scope
+/******/ 	const __webpack_require__ = {};
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/concatenation wrap */
+/******/ 	// wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ 	// set before the body runs so re-entrant calls (require cycles) observe
+/******/ 	// the partial exports like Node.js
+/******/ 	__webpack_require__.cw = (body) => {
+/******/ 		var mod;
+/******/ 		return () => {
+/******/ 			if (body) {
+/******/ 				var fn = body;
+/******/ 				body = 0;
+/******/ 				mod = { exports: {} };
+/******/ 				fn.call(mod.exports, mod, mod.exports);
+/******/ 			}
+/******/ 			return mod.exports;
+/******/ 		};
+/******/ 	};
+/******/ 	
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 2 modules ***!
+  \\\\******************************/
+
+// MODULE: ./body.js
+var body_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+// semicolon-free: every require below starts a statement where ASI would join
+// the block above it, and each one writes through a parenthesized member access
+const log = []
+
+{
+	log.push(\\"assign\\")
+}
+;(store_namespaceFn().nested).value = \\"assigned\\"
+
+{
+	log.push(\\"compound\\")
+}
+;(store_namespaceFn().nested).count += 2
+
+{
+	log.push(\\"update\\")
+}
+;(store_namespaceFn().nested).count++
+
+{
+	log.push(\\"computed\\")
+}
+;(store_namespaceFn().nested)[\\"flag\\"] = true
+
+{
+	log.push(\\"deep\\")
+}
+;(store_namespaceFn().nested).deep.leaf = \\"reassigned\\"
+
+{
+	log.push(\\"delete\\")
+}
+delete (store_namespaceFn().nested).gone
+
+{
+	log.push(\\"read\\")
+}
+;(store_namespaceFn().nested).value
+
+module.exports.z = () => log
+module.exports.L = () => (store_namespaceFn().nested)
+
+});
+
+// MODULE: ./store.js
+var store_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+// exported through a variable, so the exports stay statically unknown and every
+// reader below reaches the module through its wrapper accessor
+const store = {
+	nested: {
+		value: \\"original\\",
+		count: 1,
+		flag: false,
+		gone: \\"present\\",
+		deep: { leaf: \\"leaf\\" }
+	}
+};
+
+module.exports = store;
+
+});
+
+;// ./body.js
+body_namespaceFn();
+
+;// ./index.js
+
+
+it(\\"should write through a required wrapped module at a statement start\\", () => {
+	expect((0,body_namespaceFn().z)()).toEqual([
+		\\"assign\\",
+		\\"compound\\",
+		\\"update\\",
+		\\"computed\\",
+		\\"deep\\",
+		\\"delete\\",
+		\\"read\\"
+	]);
+
+	const nested = (0,body_namespaceFn().L)();
+
+	expect(nested.value).toBe(\\"assigned\\");
+	expect(nested.count).toBe(4);
+	expect(nested.flag).toBe(true);
+	expect(nested.deep.leaf).toBe(\\"reassigned\\");
+	expect(\\"gone\\" in nested).toBe(false);
+});
+
+/******/ })()
+;"
+`;
+
+exports[`ConfigCacheTestCases concatenate-modules commonjs-wrapped-assignment-asi-position-require commonjs-wrapped-assignment-asi-position-require should pre-compile to fill disk cache (2nd) 1`] = `
+"/******/ (() => { // webpackBootstrap
+/******/ 	\\"use strict\\";
+/******/ 	// The require scope
+/******/ 	const __webpack_require__ = {};
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/concatenation wrap */
+/******/ 	// wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ 	// set before the body runs so re-entrant calls (require cycles) observe
+/******/ 	// the partial exports like Node.js
+/******/ 	__webpack_require__.cw = (body) => {
+/******/ 		var mod;
+/******/ 		return () => {
+/******/ 			if (body) {
+/******/ 				var fn = body;
+/******/ 				body = 0;
+/******/ 				mod = { exports: {} };
+/******/ 				fn.call(mod.exports, mod, mod.exports);
+/******/ 			}
+/******/ 			return mod.exports;
+/******/ 		};
+/******/ 	};
+/******/ 	
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 2 modules ***!
+  \\\\******************************/
+
+// MODULE: ./body.js
+var body_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+// semicolon-free: every require below starts a statement where ASI would join
+// the block above it, and each one writes through a parenthesized member access
+const log = []
+
+{
+	log.push(\\"assign\\")
+}
+;(store_namespaceFn().nested).value = \\"assigned\\"
+
+{
+	log.push(\\"compound\\")
+}
+;(store_namespaceFn().nested).count += 2
+
+{
+	log.push(\\"update\\")
+}
+;(store_namespaceFn().nested).count++
+
+{
+	log.push(\\"computed\\")
+}
+;(store_namespaceFn().nested)[\\"flag\\"] = true
+
+{
+	log.push(\\"deep\\")
+}
+;(store_namespaceFn().nested).deep.leaf = \\"reassigned\\"
+
+{
+	log.push(\\"delete\\")
+}
+delete (store_namespaceFn().nested).gone
+
+{
+	log.push(\\"read\\")
+}
+;(store_namespaceFn().nested).value
+
+module.exports.z = () => log
+module.exports.L = () => (store_namespaceFn().nested)
+
+});
+
+// MODULE: ./store.js
+var store_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+// exported through a variable, so the exports stay statically unknown and every
+// reader below reaches the module through its wrapper accessor
+const store = {
+	nested: {
+		value: \\"original\\",
+		count: 1,
+		flag: false,
+		gone: \\"present\\",
+		deep: { leaf: \\"leaf\\" }
+	}
+};
+
+module.exports = store;
+
+});
+
+;// ./body.js
+body_namespaceFn();
+
+;// ./index.js
+
+
+it(\\"should write through a required wrapped module at a statement start\\", () => {
+	expect((0,body_namespaceFn().z)()).toEqual([
+		\\"assign\\",
+		\\"compound\\",
+		\\"update\\",
+		\\"computed\\",
+		\\"deep\\",
+		\\"delete\\",
+		\\"read\\"
+	]);
+
+	const nested = (0,body_namespaceFn().L)();
+
+	expect(nested.value).toBe(\\"assigned\\");
+	expect(nested.count).toBe(4);
+	expect(nested.flag).toBe(true);
+	expect(nested.deep.leaf).toBe(\\"reassigned\\");
+	expect(\\"gone\\" in nested).toBe(false);
+});
+
+/******/ })()
+;"
+`;

--- a/test/configCases/concatenate-modules/commonjs-wrapped-assignment-asi-position-require/__snapshots__/ConfigTest.snap
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-assignment-asi-position-require/__snapshots__/ConfigTest.snap
@@ -1,0 +1,128 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigTestCases concatenate-modules commonjs-wrapped-assignment-asi-position-require commonjs-wrapped-assignment-asi-position-require should compile 1`] = `
+"/******/ (() => { // webpackBootstrap
+/******/ 	\\"use strict\\";
+/******/ 	// The require scope
+/******/ 	const __webpack_require__ = {};
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/concatenation wrap */
+/******/ 	// wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ 	// set before the body runs so re-entrant calls (require cycles) observe
+/******/ 	// the partial exports like Node.js
+/******/ 	__webpack_require__.cw = (body) => {
+/******/ 		var mod;
+/******/ 		return () => {
+/******/ 			if (body) {
+/******/ 				var fn = body;
+/******/ 				body = 0;
+/******/ 				mod = { exports: {} };
+/******/ 				fn.call(mod.exports, mod, mod.exports);
+/******/ 			}
+/******/ 			return mod.exports;
+/******/ 		};
+/******/ 	};
+/******/ 	
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 2 modules ***!
+  \\\\******************************/
+
+// MODULE: ./body.js
+var body_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+// semicolon-free: every require below starts a statement where ASI would join
+// the block above it, and each one writes through a parenthesized member access
+const log = []
+
+{
+	log.push(\\"assign\\")
+}
+;(store_namespaceFn().nested).value = \\"assigned\\"
+
+{
+	log.push(\\"compound\\")
+}
+;(store_namespaceFn().nested).count += 2
+
+{
+	log.push(\\"update\\")
+}
+;(store_namespaceFn().nested).count++
+
+{
+	log.push(\\"computed\\")
+}
+;(store_namespaceFn().nested)[\\"flag\\"] = true
+
+{
+	log.push(\\"deep\\")
+}
+;(store_namespaceFn().nested).deep.leaf = \\"reassigned\\"
+
+{
+	log.push(\\"delete\\")
+}
+delete (store_namespaceFn().nested).gone
+
+{
+	log.push(\\"read\\")
+}
+;(store_namespaceFn().nested).value
+
+module.exports.z = () => log
+module.exports.L = () => (store_namespaceFn().nested)
+
+});
+
+// MODULE: ./store.js
+var store_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+// exported through a variable, so the exports stay statically unknown and every
+// reader below reaches the module through its wrapper accessor
+const store = {
+	nested: {
+		value: \\"original\\",
+		count: 1,
+		flag: false,
+		gone: \\"present\\",
+		deep: { leaf: \\"leaf\\" }
+	}
+};
+
+module.exports = store;
+
+});
+
+;// ./body.js
+body_namespaceFn();
+
+;// ./index.js
+
+
+it(\\"should write through a required wrapped module at a statement start\\", () => {
+	expect((0,body_namespaceFn().z)()).toEqual([
+		\\"assign\\",
+		\\"compound\\",
+		\\"update\\",
+		\\"computed\\",
+		\\"deep\\",
+		\\"delete\\",
+		\\"read\\"
+	]);
+
+	const nested = (0,body_namespaceFn().L)();
+
+	expect(nested.value).toBe(\\"assigned\\");
+	expect(nested.count).toBe(4);
+	expect(nested.flag).toBe(true);
+	expect(nested.deep.leaf).toBe(\\"reassigned\\");
+	expect(\\"gone\\" in nested).toBe(false);
+});
+
+/******/ })()
+;"
+`;

--- a/test/configCases/concatenate-modules/commonjs-wrapped-assignment-asi-position-require/body.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-assignment-asi-position-require/body.js
@@ -1,0 +1,43 @@
+"use strict";
+
+// semicolon-free: every require below starts a statement where ASI would join
+// the block above it, and each one writes through a parenthesized member access
+const log = []
+
+{
+	log.push("assign")
+}
+require("./store").nested.value = "assigned"
+
+{
+	log.push("compound")
+}
+require("./store").nested.count += 2
+
+{
+	log.push("update")
+}
+require("./store").nested.count++
+
+{
+	log.push("computed")
+}
+require("./store").nested["flag"] = true
+
+{
+	log.push("deep")
+}
+require("./store").nested.deep.leaf = "reassigned"
+
+{
+	log.push("delete")
+}
+delete require("./store").nested.gone
+
+{
+	log.push("read")
+}
+require("./store").nested.value
+
+module.exports.report = () => log
+module.exports.read = () => require("./store").nested

--- a/test/configCases/concatenate-modules/commonjs-wrapped-assignment-asi-position-require/index.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-assignment-asi-position-require/index.js
@@ -1,0 +1,21 @@
+import { read, report } from "./body";
+
+it("should write through a required wrapped module at a statement start", () => {
+	expect(report()).toEqual([
+		"assign",
+		"compound",
+		"update",
+		"computed",
+		"deep",
+		"delete",
+		"read"
+	]);
+
+	const nested = read();
+
+	expect(nested.value).toBe("assigned");
+	expect(nested.count).toBe(4);
+	expect(nested.flag).toBe(true);
+	expect(nested.deep.leaf).toBe("reassigned");
+	expect("gone" in nested).toBe(false);
+});

--- a/test/configCases/concatenate-modules/commonjs-wrapped-assignment-asi-position-require/store.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-assignment-asi-position-require/store.js
@@ -1,0 +1,15 @@
+"use strict";
+
+// exported through a variable, so the exports stay statically unknown and every
+// reader below reaches the module through its wrapper accessor
+const store = {
+	nested: {
+		value: "original",
+		count: 1,
+		flag: false,
+		gone: "present",
+		deep: { leaf: "leaf" }
+	}
+};
+
+module.exports = store;

--- a/test/configCases/concatenate-modules/commonjs-wrapped-assignment-asi-position-require/webpack.config.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-assignment-asi-position-require/webpack.config.js
@@ -1,0 +1,29 @@
+"use strict";
+
+const PLUGIN_NAME = "SnapshotBundlePlugin";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	devtool: false,
+	optimization: {
+		concatenateModules: { commonjs: true },
+		minimize: false,
+		usedExports: true,
+		moduleIds: "named",
+		chunkIds: "named"
+	},
+	plugins: [
+		/**
+		 * What this case checks is printed code, so review the bundle as a whole.
+		 * @param {import("../../../../").Compiler} compiler compiler
+		 */
+		(compiler) => {
+			compiler.hooks.compilation.tap(PLUGIN_NAME, (compilation) => {
+				compilation.hooks.afterProcessAssets.tap(PLUGIN_NAME, (assets) => {
+					expect(assets["bundle0.js"].source()).toMatchSnapshot();
+				});
+			});
+		}
+	]
+};

--- a/test/configCases/concatenate-modules/commonjs-wrapped-assignment-asi-position/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-assignment-asi-position/__snapshots__/ConfigCacheTest.snap
@@ -1,0 +1,1117 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigCacheTestCases concatenate-modules commonjs-wrapped-assignment-asi-position commonjs-wrapped-assignment-asi-position should compile 1`] = `
+"/******/ (() => { // webpackBootstrap
+/******/ 	\\"use strict\\";
+/******/ 	// The require scope
+/******/ 	const __webpack_require__ = {};
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/compat get default export */
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = (module) => {
+/******/ 		const getter = module && module.__esModule ?
+/******/ 			() => (module['default']) :
+/******/ 			() => (module);
+/******/ 		__webpack_require__.d(getter, { a: getter });
+/******/ 		return getter;
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/concatenation wrap */
+/******/ 	// wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ 	// set before the body runs so re-entrant calls (require cycles) observe
+/******/ 	// the partial exports like Node.js
+/******/ 	__webpack_require__.cw = (body) => {
+/******/ 		var mod;
+/******/ 		return () => {
+/******/ 			if (body) {
+/******/ 				var fn = body;
+/******/ 				body = 0;
+/******/ 				mod = { exports: {} };
+/******/ 				fn.call(mod.exports, mod, mod.exports);
+/******/ 			}
+/******/ 			return mod.exports;
+/******/ 		};
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/define property getters */
+/******/ 	// define getter/value functions for harmony exports
+/******/ 	__webpack_require__.d = (exports, definition) => {
+/******/ 		for(var key in definition) {
+/******/ 			if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 				Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 			}
+/******/ 		}
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/hasOwnProperty shorthand */
+/******/ 	__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop));
+/******/ 	
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 3 modules ***!
+  \\\\******************************/
+
+// MODULE: ./formats.js
+var formats_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+// exported through a variable, so the exports stay statically unknown: that is
+// what makes the module wrapped and its default import need interop
+const formats = {
+	loose: {
+		value: \\"original\\",
+		count: 1,
+		flag: false,
+		gone: \\"present\\",
+		deep: { leaf: \\"leaf\\" },
+		run: () => \\"ran\\",
+		Ctor: function Ctor() {
+			this.tag = \\"ctor\\";
+		}
+	},
+	strict: {
+		value: \\"original\\",
+		count: 1,
+		flag: false,
+		deep: { leaf: \\"leaf\\" }
+	},
+	named: () => \\"named\\"
+};
+
+module.exports = formats;
+
+});
+
+;// ./formats.js
+formats_namespaceFn();
+
+function formats_default() { return formats_default.c || (formats_default.c = __webpack_require__.n(formats_namespaceFn())); }
+;// ./loose.js
+// javascript/auto: the default import reads through the interop accessor, which
+// carries an ASI guard of its own that must not end up inside the parentheses
+
+
+
+
+function mutate() {
+	const log = []
+
+	{
+		log.push(\\"assign\\")
+	}
+	;((formats_default()()).loose).value = \\"assigned\\"
+
+	{
+		log.push(\\"compound\\")
+	}
+	;((formats_default()()).loose).count += 2
+
+	{
+		log.push(\\"update\\")
+	}
+	;((formats_default()()).loose).count++
+
+	{
+		log.push(\\"computed\\")
+	}
+	;((formats_default()()).loose)[\\"flag\\"] = true
+
+	{
+		log.push(\\"deep\\")
+	}
+	;((formats_default()()).loose).deep.leaf = \\"reassigned\\"
+
+	{
+		log.push(\\"delete\\")
+	}
+	delete ((formats_default()()).loose).gone
+
+	{
+		log.push(\\"typeof\\")
+	}
+	typeof ((formats_default()()).loose).value
+
+	{
+		log.push(\\"void\\")
+	}
+	void ((formats_default()()).loose).value
+
+	{
+		log.push(\\"call\\")
+	}
+	;(formats_default()().loose).run()
+
+	{
+		log.push(\\"new\\")
+	}
+	new ((formats_default()()).loose).Ctor()
+
+	{
+		log.push(\\"named\\")
+	}
+	;(0,formats_namespaceFn().named)()
+
+	{
+		log.push(\\"namespaceCall\\")
+	}
+	;(formats_namespaceFn().named)()
+
+	{
+		log.push(\\"namespace\\")
+	}
+	;(formats_namespaceFn())
+
+	{
+		log.push(\\"default\\")
+	}
+	;(formats_default()())
+
+	return log
+}
+
+function read() {
+	return ((formats_default()()).loose)
+}
+
+;// ./strict.mjs
+// strict ESM: the default import binds to the wrapper accessor directly, so the
+// same shapes take the other interop path into the one wrapped module
+
+
+
+function strict_mutate() {
+	const log = []
+
+	{
+		log.push(\\"assign\\")
+	}
+	;(formats_namespaceFn().strict).value = \\"assigned\\"
+
+	{
+		log.push(\\"compound\\")
+	}
+	;(formats_namespaceFn().strict).count += 2
+
+	{
+		log.push(\\"update\\")
+	}
+	;(formats_namespaceFn().strict).count++
+
+	{
+		log.push(\\"computed\\")
+	}
+	;(formats_namespaceFn().strict)[\\"flag\\"] = true
+
+	{
+		log.push(\\"deep\\")
+	}
+	;(formats_namespaceFn().strict).deep.leaf = \\"reassigned\\"
+
+	{
+		log.push(\\"namespaceAssign\\")
+	}
+	;(formats_namespaceFn().strict).deep.leaf = \\"namespaced\\"
+
+	return log
+}
+
+function strict_read() {
+	return (formats_namespaceFn().strict)
+}
+
+;// ./index.js
+
+
+
+it(\\"should write through an interop default import at a statement start\\", () => {
+	expect(mutate()).toEqual([
+		\\"assign\\",
+		\\"compound\\",
+		\\"update\\",
+		\\"computed\\",
+		\\"deep\\",
+		\\"delete\\",
+		\\"typeof\\",
+		\\"void\\",
+		\\"call\\",
+		\\"new\\",
+		\\"named\\",
+		\\"namespaceCall\\",
+		\\"namespace\\",
+		\\"default\\"
+	]);
+
+	const loose = read();
+
+	expect(loose.value).toBe(\\"assigned\\");
+	expect(loose.count).toBe(4);
+	expect(loose.flag).toBe(true);
+	expect(loose.deep.leaf).toBe(\\"reassigned\\");
+	expect(\\"gone\\" in loose).toBe(false);
+});
+
+it(\\"should write through a strict ESM default import at a statement start\\", () => {
+	expect(strict_mutate()).toEqual([
+		\\"assign\\",
+		\\"compound\\",
+		\\"update\\",
+		\\"computed\\",
+		\\"deep\\",
+		\\"namespaceAssign\\"
+	]);
+
+	const strict = strict_read();
+
+	expect(strict.value).toBe(\\"assigned\\");
+	expect(strict.count).toBe(4);
+	expect(strict.flag).toBe(true);
+	expect(strict.deep.leaf).toBe(\\"namespaced\\");
+});
+
+it(\\"should reach both interop paths of the one wrapped module\\", () => {
+	expect(read()).not.toBe(strict_read());
+	expect(mutate().length).toBeGreaterThan(0);
+	expect(read().count).toBe(7);
+});
+
+/******/ })()
+;"
+`;
+
+exports[`ConfigCacheTestCases concatenate-modules commonjs-wrapped-assignment-asi-position commonjs-wrapped-assignment-asi-position should compile 2`] = `
+"/******/ (() => { // webpackBootstrap
+/******/ 	\\"use strict\\";
+/******/ 	// The require scope
+/******/ 	const __webpack_require__ = {};
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/compat get default export */
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = (module) => {
+/******/ 		const getter = module && module.__esModule ?
+/******/ 			() => (module['default']) :
+/******/ 			() => (module);
+/******/ 		__webpack_require__.d(getter, { a: getter });
+/******/ 		return getter;
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/concatenation wrap */
+/******/ 	// wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ 	// set before the body runs so re-entrant calls (require cycles) observe
+/******/ 	// the partial exports like Node.js
+/******/ 	__webpack_require__.cw = (body) => {
+/******/ 		var mod;
+/******/ 		return () => {
+/******/ 			if (body) {
+/******/ 				var fn = body;
+/******/ 				body = 0;
+/******/ 				mod = { exports: {} };
+/******/ 				fn.call(mod.exports, mod, mod.exports);
+/******/ 			}
+/******/ 			return mod.exports;
+/******/ 		};
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/define property getters */
+/******/ 	// define getter/value functions for harmony exports
+/******/ 	__webpack_require__.d = (exports, definition) => {
+/******/ 		for(var key in definition) {
+/******/ 			if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 				Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 			}
+/******/ 		}
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/hasOwnProperty shorthand */
+/******/ 	__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop));
+/******/ 	
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 3 modules ***!
+  \\\\******************************/
+
+// MODULE: ./formats.js
+var formats_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+// exported through a variable, so the exports stay statically unknown: that is
+// what makes the module wrapped and its default import need interop
+const formats = {
+	loose: {
+		value: \\"original\\",
+		count: 1,
+		flag: false,
+		gone: \\"present\\",
+		deep: { leaf: \\"leaf\\" },
+		run: () => \\"ran\\",
+		Ctor: function Ctor() {
+			this.tag = \\"ctor\\";
+		}
+	},
+	strict: {
+		value: \\"original\\",
+		count: 1,
+		flag: false,
+		deep: { leaf: \\"leaf\\" }
+	},
+	named: () => \\"named\\"
+};
+
+module.exports = formats;
+
+});
+
+;// ./formats.js
+formats_namespaceFn();
+
+function formats_default() { return formats_default.c || (formats_default.c = __webpack_require__.n(formats_namespaceFn())); }
+;// ./loose.js
+// javascript/auto: the default import reads through the interop accessor, which
+// carries an ASI guard of its own that must not end up inside the parentheses
+
+
+
+
+function mutate() {
+	const log = []
+
+	{
+		log.push(\\"assign\\")
+	}
+	;((formats_default()()).loose).value = \\"assigned\\"
+
+	{
+		log.push(\\"compound\\")
+	}
+	;((formats_default()()).loose).count += 2
+
+	{
+		log.push(\\"update\\")
+	}
+	;((formats_default()()).loose).count++
+
+	{
+		log.push(\\"computed\\")
+	}
+	;((formats_default()()).loose)[\\"flag\\"] = true
+
+	{
+		log.push(\\"deep\\")
+	}
+	;((formats_default()()).loose).deep.leaf = \\"reassigned\\"
+
+	{
+		log.push(\\"delete\\")
+	}
+	delete ((formats_default()()).loose).gone
+
+	{
+		log.push(\\"typeof\\")
+	}
+	typeof ((formats_default()()).loose).value
+
+	{
+		log.push(\\"void\\")
+	}
+	void ((formats_default()()).loose).value
+
+	{
+		log.push(\\"call\\")
+	}
+	;(formats_default()().loose).run()
+
+	{
+		log.push(\\"new\\")
+	}
+	new ((formats_default()()).loose).Ctor()
+
+	{
+		log.push(\\"named\\")
+	}
+	;(0,formats_namespaceFn().named)()
+
+	{
+		log.push(\\"namespaceCall\\")
+	}
+	;(formats_namespaceFn().named)()
+
+	{
+		log.push(\\"namespace\\")
+	}
+	;(formats_namespaceFn())
+
+	{
+		log.push(\\"default\\")
+	}
+	;(formats_default()())
+
+	return log
+}
+
+function read() {
+	return ((formats_default()()).loose)
+}
+
+;// ./strict.mjs
+// strict ESM: the default import binds to the wrapper accessor directly, so the
+// same shapes take the other interop path into the one wrapped module
+
+
+
+function strict_mutate() {
+	const log = []
+
+	{
+		log.push(\\"assign\\")
+	}
+	;(formats_namespaceFn().strict).value = \\"assigned\\"
+
+	{
+		log.push(\\"compound\\")
+	}
+	;(formats_namespaceFn().strict).count += 2
+
+	{
+		log.push(\\"update\\")
+	}
+	;(formats_namespaceFn().strict).count++
+
+	{
+		log.push(\\"computed\\")
+	}
+	;(formats_namespaceFn().strict)[\\"flag\\"] = true
+
+	{
+		log.push(\\"deep\\")
+	}
+	;(formats_namespaceFn().strict).deep.leaf = \\"reassigned\\"
+
+	{
+		log.push(\\"namespaceAssign\\")
+	}
+	;(formats_namespaceFn().strict).deep.leaf = \\"namespaced\\"
+
+	return log
+}
+
+function strict_read() {
+	return (formats_namespaceFn().strict)
+}
+
+;// ./index.js
+
+
+
+it(\\"should write through an interop default import at a statement start\\", () => {
+	expect(mutate()).toEqual([
+		\\"assign\\",
+		\\"compound\\",
+		\\"update\\",
+		\\"computed\\",
+		\\"deep\\",
+		\\"delete\\",
+		\\"typeof\\",
+		\\"void\\",
+		\\"call\\",
+		\\"new\\",
+		\\"named\\",
+		\\"namespaceCall\\",
+		\\"namespace\\",
+		\\"default\\"
+	]);
+
+	const loose = read();
+
+	expect(loose.value).toBe(\\"assigned\\");
+	expect(loose.count).toBe(4);
+	expect(loose.flag).toBe(true);
+	expect(loose.deep.leaf).toBe(\\"reassigned\\");
+	expect(\\"gone\\" in loose).toBe(false);
+});
+
+it(\\"should write through a strict ESM default import at a statement start\\", () => {
+	expect(strict_mutate()).toEqual([
+		\\"assign\\",
+		\\"compound\\",
+		\\"update\\",
+		\\"computed\\",
+		\\"deep\\",
+		\\"namespaceAssign\\"
+	]);
+
+	const strict = strict_read();
+
+	expect(strict.value).toBe(\\"assigned\\");
+	expect(strict.count).toBe(4);
+	expect(strict.flag).toBe(true);
+	expect(strict.deep.leaf).toBe(\\"namespaced\\");
+});
+
+it(\\"should reach both interop paths of the one wrapped module\\", () => {
+	expect(read()).not.toBe(strict_read());
+	expect(mutate().length).toBeGreaterThan(0);
+	expect(read().count).toBe(7);
+});
+
+/******/ })()
+;"
+`;
+
+exports[`ConfigCacheTestCases concatenate-modules commonjs-wrapped-assignment-asi-position commonjs-wrapped-assignment-asi-position should pre-compile to fill disk cache (1st) 1`] = `
+"/******/ (() => { // webpackBootstrap
+/******/ 	\\"use strict\\";
+/******/ 	// The require scope
+/******/ 	const __webpack_require__ = {};
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/compat get default export */
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = (module) => {
+/******/ 		const getter = module && module.__esModule ?
+/******/ 			() => (module['default']) :
+/******/ 			() => (module);
+/******/ 		__webpack_require__.d(getter, { a: getter });
+/******/ 		return getter;
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/concatenation wrap */
+/******/ 	// wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ 	// set before the body runs so re-entrant calls (require cycles) observe
+/******/ 	// the partial exports like Node.js
+/******/ 	__webpack_require__.cw = (body) => {
+/******/ 		var mod;
+/******/ 		return () => {
+/******/ 			if (body) {
+/******/ 				var fn = body;
+/******/ 				body = 0;
+/******/ 				mod = { exports: {} };
+/******/ 				fn.call(mod.exports, mod, mod.exports);
+/******/ 			}
+/******/ 			return mod.exports;
+/******/ 		};
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/define property getters */
+/******/ 	// define getter/value functions for harmony exports
+/******/ 	__webpack_require__.d = (exports, definition) => {
+/******/ 		for(var key in definition) {
+/******/ 			if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 				Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 			}
+/******/ 		}
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/hasOwnProperty shorthand */
+/******/ 	__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop));
+/******/ 	
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 3 modules ***!
+  \\\\******************************/
+
+// MODULE: ./formats.js
+var formats_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+// exported through a variable, so the exports stay statically unknown: that is
+// what makes the module wrapped and its default import need interop
+const formats = {
+	loose: {
+		value: \\"original\\",
+		count: 1,
+		flag: false,
+		gone: \\"present\\",
+		deep: { leaf: \\"leaf\\" },
+		run: () => \\"ran\\",
+		Ctor: function Ctor() {
+			this.tag = \\"ctor\\";
+		}
+	},
+	strict: {
+		value: \\"original\\",
+		count: 1,
+		flag: false,
+		deep: { leaf: \\"leaf\\" }
+	},
+	named: () => \\"named\\"
+};
+
+module.exports = formats;
+
+});
+
+;// ./formats.js
+formats_namespaceFn();
+
+function formats_default() { return formats_default.c || (formats_default.c = __webpack_require__.n(formats_namespaceFn())); }
+;// ./loose.js
+// javascript/auto: the default import reads through the interop accessor, which
+// carries an ASI guard of its own that must not end up inside the parentheses
+
+
+
+
+function mutate() {
+	const log = []
+
+	{
+		log.push(\\"assign\\")
+	}
+	;((formats_default()()).loose).value = \\"assigned\\"
+
+	{
+		log.push(\\"compound\\")
+	}
+	;((formats_default()()).loose).count += 2
+
+	{
+		log.push(\\"update\\")
+	}
+	;((formats_default()()).loose).count++
+
+	{
+		log.push(\\"computed\\")
+	}
+	;((formats_default()()).loose)[\\"flag\\"] = true
+
+	{
+		log.push(\\"deep\\")
+	}
+	;((formats_default()()).loose).deep.leaf = \\"reassigned\\"
+
+	{
+		log.push(\\"delete\\")
+	}
+	delete ((formats_default()()).loose).gone
+
+	{
+		log.push(\\"typeof\\")
+	}
+	typeof ((formats_default()()).loose).value
+
+	{
+		log.push(\\"void\\")
+	}
+	void ((formats_default()()).loose).value
+
+	{
+		log.push(\\"call\\")
+	}
+	;(formats_default()().loose).run()
+
+	{
+		log.push(\\"new\\")
+	}
+	new ((formats_default()()).loose).Ctor()
+
+	{
+		log.push(\\"named\\")
+	}
+	;(0,formats_namespaceFn().named)()
+
+	{
+		log.push(\\"namespaceCall\\")
+	}
+	;(formats_namespaceFn().named)()
+
+	{
+		log.push(\\"namespace\\")
+	}
+	;(formats_namespaceFn())
+
+	{
+		log.push(\\"default\\")
+	}
+	;(formats_default()())
+
+	return log
+}
+
+function read() {
+	return ((formats_default()()).loose)
+}
+
+;// ./strict.mjs
+// strict ESM: the default import binds to the wrapper accessor directly, so the
+// same shapes take the other interop path into the one wrapped module
+
+
+
+function strict_mutate() {
+	const log = []
+
+	{
+		log.push(\\"assign\\")
+	}
+	;(formats_namespaceFn().strict).value = \\"assigned\\"
+
+	{
+		log.push(\\"compound\\")
+	}
+	;(formats_namespaceFn().strict).count += 2
+
+	{
+		log.push(\\"update\\")
+	}
+	;(formats_namespaceFn().strict).count++
+
+	{
+		log.push(\\"computed\\")
+	}
+	;(formats_namespaceFn().strict)[\\"flag\\"] = true
+
+	{
+		log.push(\\"deep\\")
+	}
+	;(formats_namespaceFn().strict).deep.leaf = \\"reassigned\\"
+
+	{
+		log.push(\\"namespaceAssign\\")
+	}
+	;(formats_namespaceFn().strict).deep.leaf = \\"namespaced\\"
+
+	return log
+}
+
+function strict_read() {
+	return (formats_namespaceFn().strict)
+}
+
+;// ./index.js
+
+
+
+it(\\"should write through an interop default import at a statement start\\", () => {
+	expect(mutate()).toEqual([
+		\\"assign\\",
+		\\"compound\\",
+		\\"update\\",
+		\\"computed\\",
+		\\"deep\\",
+		\\"delete\\",
+		\\"typeof\\",
+		\\"void\\",
+		\\"call\\",
+		\\"new\\",
+		\\"named\\",
+		\\"namespaceCall\\",
+		\\"namespace\\",
+		\\"default\\"
+	]);
+
+	const loose = read();
+
+	expect(loose.value).toBe(\\"assigned\\");
+	expect(loose.count).toBe(4);
+	expect(loose.flag).toBe(true);
+	expect(loose.deep.leaf).toBe(\\"reassigned\\");
+	expect(\\"gone\\" in loose).toBe(false);
+});
+
+it(\\"should write through a strict ESM default import at a statement start\\", () => {
+	expect(strict_mutate()).toEqual([
+		\\"assign\\",
+		\\"compound\\",
+		\\"update\\",
+		\\"computed\\",
+		\\"deep\\",
+		\\"namespaceAssign\\"
+	]);
+
+	const strict = strict_read();
+
+	expect(strict.value).toBe(\\"assigned\\");
+	expect(strict.count).toBe(4);
+	expect(strict.flag).toBe(true);
+	expect(strict.deep.leaf).toBe(\\"namespaced\\");
+});
+
+it(\\"should reach both interop paths of the one wrapped module\\", () => {
+	expect(read()).not.toBe(strict_read());
+	expect(mutate().length).toBeGreaterThan(0);
+	expect(read().count).toBe(7);
+});
+
+/******/ })()
+;"
+`;
+
+exports[`ConfigCacheTestCases concatenate-modules commonjs-wrapped-assignment-asi-position commonjs-wrapped-assignment-asi-position should pre-compile to fill disk cache (2nd) 1`] = `
+"/******/ (() => { // webpackBootstrap
+/******/ 	\\"use strict\\";
+/******/ 	// The require scope
+/******/ 	const __webpack_require__ = {};
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/compat get default export */
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = (module) => {
+/******/ 		const getter = module && module.__esModule ?
+/******/ 			() => (module['default']) :
+/******/ 			() => (module);
+/******/ 		__webpack_require__.d(getter, { a: getter });
+/******/ 		return getter;
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/concatenation wrap */
+/******/ 	// wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ 	// set before the body runs so re-entrant calls (require cycles) observe
+/******/ 	// the partial exports like Node.js
+/******/ 	__webpack_require__.cw = (body) => {
+/******/ 		var mod;
+/******/ 		return () => {
+/******/ 			if (body) {
+/******/ 				var fn = body;
+/******/ 				body = 0;
+/******/ 				mod = { exports: {} };
+/******/ 				fn.call(mod.exports, mod, mod.exports);
+/******/ 			}
+/******/ 			return mod.exports;
+/******/ 		};
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/define property getters */
+/******/ 	// define getter/value functions for harmony exports
+/******/ 	__webpack_require__.d = (exports, definition) => {
+/******/ 		for(var key in definition) {
+/******/ 			if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 				Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 			}
+/******/ 		}
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/hasOwnProperty shorthand */
+/******/ 	__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop));
+/******/ 	
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 3 modules ***!
+  \\\\******************************/
+
+// MODULE: ./formats.js
+var formats_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+// exported through a variable, so the exports stay statically unknown: that is
+// what makes the module wrapped and its default import need interop
+const formats = {
+	loose: {
+		value: \\"original\\",
+		count: 1,
+		flag: false,
+		gone: \\"present\\",
+		deep: { leaf: \\"leaf\\" },
+		run: () => \\"ran\\",
+		Ctor: function Ctor() {
+			this.tag = \\"ctor\\";
+		}
+	},
+	strict: {
+		value: \\"original\\",
+		count: 1,
+		flag: false,
+		deep: { leaf: \\"leaf\\" }
+	},
+	named: () => \\"named\\"
+};
+
+module.exports = formats;
+
+});
+
+;// ./formats.js
+formats_namespaceFn();
+
+function formats_default() { return formats_default.c || (formats_default.c = __webpack_require__.n(formats_namespaceFn())); }
+;// ./loose.js
+// javascript/auto: the default import reads through the interop accessor, which
+// carries an ASI guard of its own that must not end up inside the parentheses
+
+
+
+
+function mutate() {
+	const log = []
+
+	{
+		log.push(\\"assign\\")
+	}
+	;((formats_default()()).loose).value = \\"assigned\\"
+
+	{
+		log.push(\\"compound\\")
+	}
+	;((formats_default()()).loose).count += 2
+
+	{
+		log.push(\\"update\\")
+	}
+	;((formats_default()()).loose).count++
+
+	{
+		log.push(\\"computed\\")
+	}
+	;((formats_default()()).loose)[\\"flag\\"] = true
+
+	{
+		log.push(\\"deep\\")
+	}
+	;((formats_default()()).loose).deep.leaf = \\"reassigned\\"
+
+	{
+		log.push(\\"delete\\")
+	}
+	delete ((formats_default()()).loose).gone
+
+	{
+		log.push(\\"typeof\\")
+	}
+	typeof ((formats_default()()).loose).value
+
+	{
+		log.push(\\"void\\")
+	}
+	void ((formats_default()()).loose).value
+
+	{
+		log.push(\\"call\\")
+	}
+	;(formats_default()().loose).run()
+
+	{
+		log.push(\\"new\\")
+	}
+	new ((formats_default()()).loose).Ctor()
+
+	{
+		log.push(\\"named\\")
+	}
+	;(0,formats_namespaceFn().named)()
+
+	{
+		log.push(\\"namespaceCall\\")
+	}
+	;(formats_namespaceFn().named)()
+
+	{
+		log.push(\\"namespace\\")
+	}
+	;(formats_namespaceFn())
+
+	{
+		log.push(\\"default\\")
+	}
+	;(formats_default()())
+
+	return log
+}
+
+function read() {
+	return ((formats_default()()).loose)
+}
+
+;// ./strict.mjs
+// strict ESM: the default import binds to the wrapper accessor directly, so the
+// same shapes take the other interop path into the one wrapped module
+
+
+
+function strict_mutate() {
+	const log = []
+
+	{
+		log.push(\\"assign\\")
+	}
+	;(formats_namespaceFn().strict).value = \\"assigned\\"
+
+	{
+		log.push(\\"compound\\")
+	}
+	;(formats_namespaceFn().strict).count += 2
+
+	{
+		log.push(\\"update\\")
+	}
+	;(formats_namespaceFn().strict).count++
+
+	{
+		log.push(\\"computed\\")
+	}
+	;(formats_namespaceFn().strict)[\\"flag\\"] = true
+
+	{
+		log.push(\\"deep\\")
+	}
+	;(formats_namespaceFn().strict).deep.leaf = \\"reassigned\\"
+
+	{
+		log.push(\\"namespaceAssign\\")
+	}
+	;(formats_namespaceFn().strict).deep.leaf = \\"namespaced\\"
+
+	return log
+}
+
+function strict_read() {
+	return (formats_namespaceFn().strict)
+}
+
+;// ./index.js
+
+
+
+it(\\"should write through an interop default import at a statement start\\", () => {
+	expect(mutate()).toEqual([
+		\\"assign\\",
+		\\"compound\\",
+		\\"update\\",
+		\\"computed\\",
+		\\"deep\\",
+		\\"delete\\",
+		\\"typeof\\",
+		\\"void\\",
+		\\"call\\",
+		\\"new\\",
+		\\"named\\",
+		\\"namespaceCall\\",
+		\\"namespace\\",
+		\\"default\\"
+	]);
+
+	const loose = read();
+
+	expect(loose.value).toBe(\\"assigned\\");
+	expect(loose.count).toBe(4);
+	expect(loose.flag).toBe(true);
+	expect(loose.deep.leaf).toBe(\\"reassigned\\");
+	expect(\\"gone\\" in loose).toBe(false);
+});
+
+it(\\"should write through a strict ESM default import at a statement start\\", () => {
+	expect(strict_mutate()).toEqual([
+		\\"assign\\",
+		\\"compound\\",
+		\\"update\\",
+		\\"computed\\",
+		\\"deep\\",
+		\\"namespaceAssign\\"
+	]);
+
+	const strict = strict_read();
+
+	expect(strict.value).toBe(\\"assigned\\");
+	expect(strict.count).toBe(4);
+	expect(strict.flag).toBe(true);
+	expect(strict.deep.leaf).toBe(\\"namespaced\\");
+});
+
+it(\\"should reach both interop paths of the one wrapped module\\", () => {
+	expect(read()).not.toBe(strict_read());
+	expect(mutate().length).toBeGreaterThan(0);
+	expect(read().count).toBe(7);
+});
+
+/******/ })()
+;"
+`;

--- a/test/configCases/concatenate-modules/commonjs-wrapped-assignment-asi-position/__snapshots__/ConfigTest.snap
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-assignment-asi-position/__snapshots__/ConfigTest.snap
@@ -1,0 +1,280 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigTestCases concatenate-modules commonjs-wrapped-assignment-asi-position commonjs-wrapped-assignment-asi-position should compile 1`] = `
+"/******/ (() => { // webpackBootstrap
+/******/ 	\\"use strict\\";
+/******/ 	// The require scope
+/******/ 	const __webpack_require__ = {};
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/compat get default export */
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = (module) => {
+/******/ 		const getter = module && module.__esModule ?
+/******/ 			() => (module['default']) :
+/******/ 			() => (module);
+/******/ 		__webpack_require__.d(getter, { a: getter });
+/******/ 		return getter;
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/concatenation wrap */
+/******/ 	// wrap a concatenated module body as a lazy, memoized accessor; mod is
+/******/ 	// set before the body runs so re-entrant calls (require cycles) observe
+/******/ 	// the partial exports like Node.js
+/******/ 	__webpack_require__.cw = (body) => {
+/******/ 		var mod;
+/******/ 		return () => {
+/******/ 			if (body) {
+/******/ 				var fn = body;
+/******/ 				body = 0;
+/******/ 				mod = { exports: {} };
+/******/ 				fn.call(mod.exports, mod, mod.exports);
+/******/ 			}
+/******/ 			return mod.exports;
+/******/ 		};
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/define property getters */
+/******/ 	// define getter/value functions for harmony exports
+/******/ 	__webpack_require__.d = (exports, definition) => {
+/******/ 		for(var key in definition) {
+/******/ 			if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 				Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 			}
+/******/ 		}
+/******/ 	};
+/******/ 	
+/******/ 	/* webpack/runtime/hasOwnProperty shorthand */
+/******/ 	__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop));
+/******/ 	
+/************************************************************************/
+/*!******************************!*\\\\
+  !*** ./index.js + 3 modules ***!
+  \\\\******************************/
+
+// MODULE: ./formats.js
+var formats_namespaceFn = /*#__PURE__*/__webpack_require__.cw(function(module, exports) {
+
+
+// exported through a variable, so the exports stay statically unknown: that is
+// what makes the module wrapped and its default import need interop
+const formats = {
+	loose: {
+		value: \\"original\\",
+		count: 1,
+		flag: false,
+		gone: \\"present\\",
+		deep: { leaf: \\"leaf\\" },
+		run: () => \\"ran\\",
+		Ctor: function Ctor() {
+			this.tag = \\"ctor\\";
+		}
+	},
+	strict: {
+		value: \\"original\\",
+		count: 1,
+		flag: false,
+		deep: { leaf: \\"leaf\\" }
+	},
+	named: () => \\"named\\"
+};
+
+module.exports = formats;
+
+});
+
+;// ./formats.js
+formats_namespaceFn();
+
+function formats_default() { return formats_default.c || (formats_default.c = __webpack_require__.n(formats_namespaceFn())); }
+;// ./loose.js
+// javascript/auto: the default import reads through the interop accessor, which
+// carries an ASI guard of its own that must not end up inside the parentheses
+
+
+
+
+function mutate() {
+	const log = []
+
+	{
+		log.push(\\"assign\\")
+	}
+	;((formats_default()()).loose).value = \\"assigned\\"
+
+	{
+		log.push(\\"compound\\")
+	}
+	;((formats_default()()).loose).count += 2
+
+	{
+		log.push(\\"update\\")
+	}
+	;((formats_default()()).loose).count++
+
+	{
+		log.push(\\"computed\\")
+	}
+	;((formats_default()()).loose)[\\"flag\\"] = true
+
+	{
+		log.push(\\"deep\\")
+	}
+	;((formats_default()()).loose).deep.leaf = \\"reassigned\\"
+
+	{
+		log.push(\\"delete\\")
+	}
+	delete ((formats_default()()).loose).gone
+
+	{
+		log.push(\\"typeof\\")
+	}
+	typeof ((formats_default()()).loose).value
+
+	{
+		log.push(\\"void\\")
+	}
+	void ((formats_default()()).loose).value
+
+	{
+		log.push(\\"call\\")
+	}
+	;(formats_default()().loose).run()
+
+	{
+		log.push(\\"new\\")
+	}
+	new ((formats_default()()).loose).Ctor()
+
+	{
+		log.push(\\"named\\")
+	}
+	;(0,formats_namespaceFn().named)()
+
+	{
+		log.push(\\"namespaceCall\\")
+	}
+	;(formats_namespaceFn().named)()
+
+	{
+		log.push(\\"namespace\\")
+	}
+	;(formats_namespaceFn())
+
+	{
+		log.push(\\"default\\")
+	}
+	;(formats_default()())
+
+	return log
+}
+
+function read() {
+	return ((formats_default()()).loose)
+}
+
+;// ./strict.mjs
+// strict ESM: the default import binds to the wrapper accessor directly, so the
+// same shapes take the other interop path into the one wrapped module
+
+
+
+function strict_mutate() {
+	const log = []
+
+	{
+		log.push(\\"assign\\")
+	}
+	;(formats_namespaceFn().strict).value = \\"assigned\\"
+
+	{
+		log.push(\\"compound\\")
+	}
+	;(formats_namespaceFn().strict).count += 2
+
+	{
+		log.push(\\"update\\")
+	}
+	;(formats_namespaceFn().strict).count++
+
+	{
+		log.push(\\"computed\\")
+	}
+	;(formats_namespaceFn().strict)[\\"flag\\"] = true
+
+	{
+		log.push(\\"deep\\")
+	}
+	;(formats_namespaceFn().strict).deep.leaf = \\"reassigned\\"
+
+	{
+		log.push(\\"namespaceAssign\\")
+	}
+	;(formats_namespaceFn().strict).deep.leaf = \\"namespaced\\"
+
+	return log
+}
+
+function strict_read() {
+	return (formats_namespaceFn().strict)
+}
+
+;// ./index.js
+
+
+
+it(\\"should write through an interop default import at a statement start\\", () => {
+	expect(mutate()).toEqual([
+		\\"assign\\",
+		\\"compound\\",
+		\\"update\\",
+		\\"computed\\",
+		\\"deep\\",
+		\\"delete\\",
+		\\"typeof\\",
+		\\"void\\",
+		\\"call\\",
+		\\"new\\",
+		\\"named\\",
+		\\"namespaceCall\\",
+		\\"namespace\\",
+		\\"default\\"
+	]);
+
+	const loose = read();
+
+	expect(loose.value).toBe(\\"assigned\\");
+	expect(loose.count).toBe(4);
+	expect(loose.flag).toBe(true);
+	expect(loose.deep.leaf).toBe(\\"reassigned\\");
+	expect(\\"gone\\" in loose).toBe(false);
+});
+
+it(\\"should write through a strict ESM default import at a statement start\\", () => {
+	expect(strict_mutate()).toEqual([
+		\\"assign\\",
+		\\"compound\\",
+		\\"update\\",
+		\\"computed\\",
+		\\"deep\\",
+		\\"namespaceAssign\\"
+	]);
+
+	const strict = strict_read();
+
+	expect(strict.value).toBe(\\"assigned\\");
+	expect(strict.count).toBe(4);
+	expect(strict.flag).toBe(true);
+	expect(strict.deep.leaf).toBe(\\"namespaced\\");
+});
+
+it(\\"should reach both interop paths of the one wrapped module\\", () => {
+	expect(read()).not.toBe(strict_read());
+	expect(mutate().length).toBeGreaterThan(0);
+	expect(read().count).toBe(7);
+});
+
+/******/ })()
+;"
+`;

--- a/test/configCases/concatenate-modules/commonjs-wrapped-assignment-asi-position/formats.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-assignment-asi-position/formats.js
@@ -1,0 +1,26 @@
+"use strict";
+
+// exported through a variable, so the exports stay statically unknown: that is
+// what makes the module wrapped and its default import need interop
+const formats = {
+	loose: {
+		value: "original",
+		count: 1,
+		flag: false,
+		gone: "present",
+		deep: { leaf: "leaf" },
+		run: () => "ran",
+		Ctor: function Ctor() {
+			this.tag = "ctor";
+		}
+	},
+	strict: {
+		value: "original",
+		count: 1,
+		flag: false,
+		deep: { leaf: "leaf" }
+	},
+	named: () => "named"
+};
+
+module.exports = formats;

--- a/test/configCases/concatenate-modules/commonjs-wrapped-assignment-asi-position/index.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-assignment-asi-position/index.js
@@ -1,0 +1,53 @@
+import { mutate as mutateLoose, read as readLoose } from "./loose";
+import { mutate as mutateStrict, read as readStrict } from "./strict.mjs";
+
+it("should write through an interop default import at a statement start", () => {
+	expect(mutateLoose()).toEqual([
+		"assign",
+		"compound",
+		"update",
+		"computed",
+		"deep",
+		"delete",
+		"typeof",
+		"void",
+		"call",
+		"new",
+		"named",
+		"namespaceCall",
+		"namespace",
+		"default"
+	]);
+
+	const loose = readLoose();
+
+	expect(loose.value).toBe("assigned");
+	expect(loose.count).toBe(4);
+	expect(loose.flag).toBe(true);
+	expect(loose.deep.leaf).toBe("reassigned");
+	expect("gone" in loose).toBe(false);
+});
+
+it("should write through a strict ESM default import at a statement start", () => {
+	expect(mutateStrict()).toEqual([
+		"assign",
+		"compound",
+		"update",
+		"computed",
+		"deep",
+		"namespaceAssign"
+	]);
+
+	const strict = readStrict();
+
+	expect(strict.value).toBe("assigned");
+	expect(strict.count).toBe(4);
+	expect(strict.flag).toBe(true);
+	expect(strict.deep.leaf).toBe("namespaced");
+});
+
+it("should reach both interop paths of the one wrapped module", () => {
+	expect(readLoose()).not.toBe(readStrict());
+	expect(mutateLoose().length).toBeGreaterThan(0);
+	expect(readLoose().count).toBe(7);
+});

--- a/test/configCases/concatenate-modules/commonjs-wrapped-assignment-asi-position/loose.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-assignment-asi-position/loose.js
@@ -1,0 +1,85 @@
+// javascript/auto: the default import reads through the interop accessor, which
+// carries an ASI guard of its own that must not end up inside the parentheses
+import formats from "./formats"
+import { named } from "./formats"
+import * as namespace from "./formats"
+
+export function mutate() {
+	const log = []
+
+	{
+		log.push("assign")
+	}
+	formats.loose.value = "assigned"
+
+	{
+		log.push("compound")
+	}
+	formats.loose.count += 2
+
+	{
+		log.push("update")
+	}
+	formats.loose.count++
+
+	{
+		log.push("computed")
+	}
+	formats.loose["flag"] = true
+
+	{
+		log.push("deep")
+	}
+	formats.loose.deep.leaf = "reassigned"
+
+	{
+		log.push("delete")
+	}
+	delete formats.loose.gone
+
+	{
+		log.push("typeof")
+	}
+	typeof formats.loose.value
+
+	{
+		log.push("void")
+	}
+	void formats.loose.value
+
+	{
+		log.push("call")
+	}
+	formats.loose.run()
+
+	{
+		log.push("new")
+	}
+	new formats.loose.Ctor()
+
+	{
+		log.push("named")
+	}
+	named()
+
+	{
+		log.push("namespaceCall")
+	}
+	namespace.named()
+
+	{
+		log.push("namespace")
+	}
+	namespace
+
+	{
+		log.push("default")
+	}
+	formats
+
+	return log
+}
+
+export function read() {
+	return formats.loose
+}

--- a/test/configCases/concatenate-modules/commonjs-wrapped-assignment-asi-position/strict.mjs
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-assignment-asi-position/strict.mjs
@@ -1,0 +1,44 @@
+// strict ESM: the default import binds to the wrapper accessor directly, so the
+// same shapes take the other interop path into the one wrapped module
+import formats from "./formats.js"
+import * as namespace from "./formats.js"
+
+export function mutate() {
+	const log = []
+
+	{
+		log.push("assign")
+	}
+	formats.strict.value = "assigned"
+
+	{
+		log.push("compound")
+	}
+	formats.strict.count += 2
+
+	{
+		log.push("update")
+	}
+	formats.strict.count++
+
+	{
+		log.push("computed")
+	}
+	formats.strict["flag"] = true
+
+	{
+		log.push("deep")
+	}
+	formats.strict.deep.leaf = "reassigned"
+
+	{
+		log.push("namespaceAssign")
+	}
+	namespace.default.strict.deep.leaf = "namespaced"
+
+	return log
+}
+
+export function read() {
+	return formats.strict
+}

--- a/test/configCases/concatenate-modules/commonjs-wrapped-assignment-asi-position/webpack.config.js
+++ b/test/configCases/concatenate-modules/commonjs-wrapped-assignment-asi-position/webpack.config.js
@@ -1,0 +1,29 @@
+"use strict";
+
+const PLUGIN_NAME = "SnapshotBundlePlugin";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	devtool: false,
+	optimization: {
+		concatenateModules: { commonjs: true },
+		minimize: false,
+		usedExports: true,
+		moduleIds: "named",
+		chunkIds: "named"
+	},
+	plugins: [
+		/**
+		 * What this case checks is printed code, so review the bundle as a whole.
+		 * @param {import("../../../../").Compiler} compiler compiler
+		 */
+		(compiler) => {
+			compiler.hooks.compilation.tap(PLUGIN_NAME, (compilation) => {
+				compilation.hooks.afterProcessAssets.tap(PLUGIN_NAME, (assets) => {
+					expect(assets["bundle0.js"].source()).toMatchSnapshot();
+				});
+			});
+		}
+	]
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Fixes #22052. `getFinalBinding` bakes an ASI guard into the `rawName` it returns for a `dynamic`-exports default import of a wrapped CommonJS module, and `getFinalName` then re-parenthesized that reference and prepended a guard of its own, emitting `;(;(x()()).prop)` — a nested `;` that throws `SyntaxError: Unexpected token ';'` at parse time. Only statement-start references were affected, so one line per file broke while its siblings stayed valid.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes — three `configCases/concatenate-modules` cases: `commonjs-wrapped-assignment-asi-position` (both interop paths against one wrapped module, over assignment, compound assignment, update, computed member, deep chain, `delete`, `typeof`, `void`, call, `new`, direct named import call and bare references), the same fixtures under `-output-module`, and `-require` for the `require()` route. The two import cases fail on `main` in both `ConfigTestCases` and `ConfigCacheTestCases`; every changed line and branch is covered.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

Claude Code reproduced the report, located the double guard, wrote the fix and the test cases, and ran the targeted suites, lint and coverage; I reviewed the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDVzu1fMFHqzayaaQXZCYE

---
_Generated by [Claude Code](https://claude.ai/code/session_01MDVzu1fMFHqzayaaQXZCYE)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected statement-boundary handling for concatenated CommonJS references, preventing syntax issues when references appear at the start of a statement.
  * Preserved proper behavior for wrapped CommonJS modules across default, named, and namespace access patterns.

* **Tests**
  * Added coverage for assignments, updates, nested properties, deletion, calls, and other operations through CommonJS interop paths.
  * Added output verification for generated module bundles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->