### PR TITLE
fix(html): name extracted script and link entries after their urls

### DIFF
--- a/.changeset/181-html-entry-js-asset.md
+++ b/.changeset/181-html-entry-js-asset.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Name an HTML page's chunks after its entry or file, drop its JS copy, type `text/html` exactly.
+Name an HTML page's chunks after it through `output.filename`/`cssFilename`, drop its JS copy, type `text/html` exactly.

--- a/.changeset/181-html-entry-js-asset.md
+++ b/.changeset/181-html-entry-js-asset.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Name an HTML page's chunks after its tags' urls, drop its JS copy, type `text/html` exactly.
+Name HTML chunks after their tags' urls, drop the JS copy, type `text/html`.

--- a/.changeset/181-html-entry-js-asset.md
+++ b/.changeset/181-html-entry-js-asset.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Name an HTML page's chunks after it through `output.filename`/`cssFilename`, drop its JS copy, type `text/html` exactly.
+Name an HTML page's chunks after its tags' urls, drop its JS copy, type `text/html` exactly.

--- a/lib/html/HtmlModulesPlugin.js
+++ b/lib/html/HtmlModulesPlugin.js
@@ -81,6 +81,14 @@ const getCssModulesPlugin = memoize(() => require("../css/CssModulesPlugin"));
 /** @import { HtmlModuleBuildInfo } from "./HtmlModule" */
 /** @import HtmlParser from "./HtmlParser" */
 /** @typedef {{ request: string, entryName: string, index: number, type: "script" | "script-module" | "modulepreload" | "stylesheet" | "html" | "preload" | "prefetch", css?: boolean }} HtmlEntryInfo */
+/**
+ * What one extracted entry needs to be named. Recorded in page order once
+ * every page is built, and resolved to filenames once chunks exist.
+ * @typedef {object} PendingName
+ * @property {string} base name the tag's url (or its page) asks for, before numbering
+ * @property {string} jsTemplate `output.filename` for this entry, with a `[name]` to fill in
+ * @property {string=} freeName name of a page-only entry, which emits nothing and leaves it free
+ */
 
 /** @typedef {{ outputName: string }} HtmlTransformHtmlContext */
 /** @typedef {{ outputName: string }} HtmlEmittedContext */
@@ -287,24 +295,20 @@ const DEFAULT_PAGE_NAME = "page";
 
 /**
  * The name a page lends to the entries it extracts from an inline body, which
- * has no url of its own: the page file's basename. Numbered when an entry or
- * another page already holds it.
+ * has no url of its own: the page file's basename. Numbered later, with every
+ * other name, by `claimName`.
  * @param {Module} module html module
- * @param {Set<string>} taken names already spoken for in this compilation
  * @returns {string} the page's name
  */
-const getPageFileName = (module, taken) => {
+const getPageFileName = (module) => {
 	const { resource } = /** @type {NormalModule} */ (module);
 	// A `data:` page is a wrapper webpack writes, with no file behind it.
-	let name = DEFAULT_PAGE_NAME;
 	if (typeof resource === "string" && !resource.startsWith("data:")) {
 		const { path: file } = parseResource(resource);
-		name = basename(file, extname(file)) || DEFAULT_PAGE_NAME;
+		const name = basename(file, extname(file));
+		if (name !== "") return name;
 	}
-	const base = name;
-	for (let index = 1; taken.has(name); index++) name = `${base}${index}`;
-	taken.add(name);
-	return name;
+	return DEFAULT_PAGE_NAME;
 };
 
 /**
@@ -625,11 +629,11 @@ class HtmlModulesPlugin {
 		// `finishMake` creates their entries without scanning the whole module
 		// graph), the stylesheet entry names (read in `afterChunks`) and the html
 		// options of every emitted page, keyed by its asset name.
-		/** @type {WeakMap<import("../Compilation"), { htmlModules: Set<Module>, stylesheetEntries: Set<string>, cssBaseNames: Map<string, string>, takenCssNames: Set<string>, htmlAssetOptions: Map<string, OutputHtmlOptions> }>} */
+		/** @type {WeakMap<import("../Compilation"), { htmlModules: Set<Module>, stylesheetEntries: Set<string>, pendingNames: Map<string, PendingName>, htmlAssetOptions: Map<string, OutputHtmlOptions> }>} */
 		const compilationState = new WeakMap();
 		/**
 		 * @param {import("../Compilation")} compilation compilation
-		 * @returns {{ htmlModules: Set<Module>, stylesheetEntries: Set<string>, cssBaseNames: Map<string, string>, takenCssNames: Set<string>, htmlAssetOptions: Map<string, OutputHtmlOptions> }} per-compilation state
+		 * @returns {{ htmlModules: Set<Module>, stylesheetEntries: Set<string>, pendingNames: Map<string, PendingName>, htmlAssetOptions: Map<string, OutputHtmlOptions> }} per-compilation state
 		 */
 		const getState = (compilation) => {
 			let state = compilationState.get(compilation);
@@ -637,8 +641,7 @@ class HtmlModulesPlugin {
 				state = {
 					htmlModules: new Set(),
 					stylesheetEntries: new Set(),
-					cssBaseNames: new Map(),
-					takenCssNames: new Set(),
+					pendingNames: new Map(),
 					htmlAssetOptions: new Map()
 				};
 				compilationState.set(compilation, state);
@@ -646,22 +649,21 @@ class HtmlModulesPlugin {
 			return state;
 		};
 		compiler.hooks.finishMake.tapAsync(PLUGIN_NAME, (compilation, callback) => {
-			const { htmlModules, stylesheetEntries, cssBaseNames, takenCssNames } =
+			const { htmlModules, stylesheetEntries, pendingNames } =
 				getState(compilation);
-			const takenNames = new Set(compilation.entries.keys());
-			// A tag the browser loads directly is an entry point, so it can no more
-			// share an emitted name with another entry than two entries can.
-			const takenJsNames = new Set(takenNames);
-			for (const name of takenNames) takenCssNames.add(name);
 			/** @type {Set<string>} */
 			const extractedNames = new Set();
+			// The page each `type: "html"` link built, so the naming walk below can
+			// follow the links in document order instead of in build order.
+			/** @type {Map<string, Module>} */
+			const linkedPages = new Map();
 
 			// Collect the entries an HTML module asks for. Only the script chains
 			// (`script`, `script-module`) share a runtime via a leader-only
 			// `dependOn`; `modulepreload`, `stylesheet` and `html` links are all
 			// independent entries (a CSS or page entry must not chain into a JS
 			// leader, or the chunk would mix unrelated outputs).
-			/** @type {(module: Module) => { context: string, request: string, name: string, dependOn: string[] | undefined, filename: string | undefined }[]} */
+			/** @type {(module: Module) => { context: string, request: string, name: string, dependOn: string[] | undefined }[]} */
 			const collectEntrySpecs = (module) => {
 				const { htmlEntries } = /** @type {HtmlModuleBuildInfo} */ (
 					module.buildInfo
@@ -669,69 +671,6 @@ class HtmlModulesPlugin {
 				if (!htmlEntries) return [];
 				const context = /** @type {string} */ (module.context);
 				const specs = [];
-				// An inline `<script>` has no url to be named after, so it borrows the
-				// page's name — its entry's name when the page is all that entry emits.
-				const pageEntry = getPageOnlyEntry(compilation, module);
-				const namedEntry =
-					pageEntry !== undefined && !extractedNames.has(pageEntry.name)
-						? pageEntry
-						: undefined;
-				// A page-only entry emits nothing of its own, so its name is free for
-				// the entries extracted from it — `app.html` keeps `app.js`.
-				if (namedEntry) {
-					takenJsNames.delete(namedEntry.name);
-					takenCssNames.delete(namedEntry.name);
-				}
-				// An `output.html` page is a wrapper webpack writes around an entry, so
-				// what it loads is that entry's own output and takes its name.
-				const wrapsEntry =
-					namedEntry !== undefined &&
-					typeof (/** @type {NormalModule} */ (module).resource) === "string" &&
-					/** @type {NormalModule} */ (module).resource.startsWith(
-						"data:text/html"
-					);
-				/** @type {string | undefined} */
-				let pageName;
-				const { filename, module: outputModule } = compilation.outputOptions;
-				const entryFilenameOption =
-					namedEntry && namedEntry.data.options.filename !== undefined
-						? namedEntry.data.options.filename
-						: filename;
-				const jsTemplate = getNamedTemplate(
-					entryFilenameOption,
-					outputModule ? ".mjs" : ".js"
-				);
-				// Named in document order, so of two tags sharing a basename the first
-				// a reader sees keeps it. A linked page is named on emit instead.
-				/** @type {HtmlEntryInfo[]} */
-				const ordered = [];
-				for (const [groupKind, group] of Object.entries(htmlEntries)) {
-					if (groupKind === "html") continue;
-					for (const entry of group) ordered.push(entry);
-				}
-				ordered.sort((a, b) => a.index - b.index);
-				/** @type {Map<string, string>} */
-				const jsNames = new Map();
-				for (const entry of ordered) {
-					let base = wrapsEntry ? undefined : getRequestBaseName(entry.request);
-					if (base === undefined) {
-						if (pageName === undefined) {
-							pageName = namedEntry
-								? namedEntry.name
-								: getPageFileName(module, takenNames);
-						}
-						base = pageName;
-					}
-					cssBaseNames.set(entry.entryName, base);
-					// A stylesheet entry emits no JavaScript, so it claims no JS name and
-					// leaves that one to a `<script src>` of the same basename.
-					if (entry.type !== "stylesheet" && !entry.css) {
-						jsNames.set(
-							entry.entryName,
-							jsTemplate.replace(/\[name\]/g, claimName(base, takenJsNames))
-						);
-					}
-				}
 				for (const [groupKind, group] of Object.entries(htmlEntries)) {
 					const isChainGroup =
 						groupKind === "script" || groupKind === "script-module";
@@ -746,9 +685,8 @@ class HtmlModulesPlugin {
 							leaderName = entry.entryName;
 						}
 						// Stylesheet entries and `as="style"` preload/prefetch entries emit
-						// a CSS chunk, so they need the CSS filename template below.
-						const emitsCss = groupKind === "stylesheet" || Boolean(entry.css);
-						if (emitsCss) {
+						// a CSS chunk, so they are named from `output.cssFilename` alone.
+						if (groupKind === "stylesheet" || Boolean(entry.css)) {
 							stylesheetEntries.add(entry.entryName);
 						}
 						extractedNames.add(entry.entryName);
@@ -756,17 +694,79 @@ class HtmlModulesPlugin {
 							context,
 							request: entry.request,
 							name: entry.entryName,
-							dependOn,
-							filename: jsNames.get(entry.entryName)
+							dependOn
 						});
 					}
 				}
 				return specs;
 			};
 
+			// Records what a page's entries ask to be named, then walks its links —
+			// once every page is built, so the order is the documents', not the builds'.
+			/** @type {(module: Module, seen: Set<Module>) => void} */
+			const recordNames = (module, seen) => {
+				if (seen.has(module)) return;
+				seen.add(module);
+				const { htmlEntries } = /** @type {HtmlModuleBuildInfo} */ (
+					module.buildInfo
+				);
+				if (!htmlEntries) return;
+				// An inline `<script>` has no url to be named after, so it borrows the
+				// page's name — its entry's name when the page is all that entry emits.
+				const pageEntry = getPageOnlyEntry(compilation, module);
+				const namedEntry =
+					pageEntry !== undefined && !extractedNames.has(pageEntry.name)
+						? pageEntry
+						: undefined;
+				const { resource } = /** @type {NormalModule} */ (module);
+				// An `output.html` page is a wrapper webpack writes around an entry, so
+				// what it loads is that entry's own output and takes its name.
+				const wrapsEntry =
+					namedEntry !== undefined &&
+					typeof resource === "string" &&
+					resource.startsWith("data:text/html");
+				const pageName = namedEntry ? namedEntry.name : getPageFileName(module);
+				const { filename, module: outputModule } = compilation.outputOptions;
+				const entryFilenameOption =
+					namedEntry && namedEntry.data.options.filename !== undefined
+						? namedEntry.data.options.filename
+						: filename;
+				const jsTemplate = getNamedTemplate(
+					entryFilenameOption,
+					outputModule ? ".mjs" : ".js"
+				);
+				// In document order, so of two tags sharing a basename the first a
+				// reader sees keeps it. A linked page is named on emit instead.
+				/** @type {HtmlEntryInfo[]} */
+				const ordered = [];
+				/** @type {HtmlEntryInfo[]} */
+				const links = [];
+				for (const [groupKind, group] of Object.entries(htmlEntries)) {
+					for (const entry of group) {
+						(groupKind === "html" ? links : ordered).push(entry);
+					}
+				}
+				ordered.sort((a, b) => a.index - b.index);
+				for (const entry of ordered) {
+					const base = wrapsEntry
+						? pageName
+						: getRequestBaseName(entry.request) || pageName;
+					pendingNames.set(entry.entryName, {
+						base,
+						jsTemplate,
+						freeName: namedEntry && namedEntry.name
+					});
+				}
+				links.sort((a, b) => a.index - b.index);
+				for (const link of links) {
+					const page = linkedPages.get(link.entryName);
+					if (page) recordNames(page, seen);
+				}
+			};
+
 			// Push one collected reference as a compilation entry; resolves with
 			// the built entry module.
-			/** @type {(spec: { context: string, request: string, name: string, dependOn: string[] | undefined, filename: string | undefined }) => Promise<Module | null>} */
+			/** @type {(spec: { context: string, request: string, name: string, dependOn: string[] | undefined }) => Promise<Module | null>} */
 			const addEntry = (spec) =>
 				new Promise((resolve, reject) => {
 					compilation.addEntry(
@@ -774,12 +774,9 @@ class HtmlModulesPlugin {
 						EntryPlugin.createDependency(spec.request, { name: spec.name }),
 						{
 							name: spec.name,
-							// Only a linked page arrives without a filename: it emits its
-							// markup from `renderManifest` and no JavaScript of its own.
-							filename:
-								spec.filename ||
-								compilation.outputOptions.chunkFilename ||
-								"[name].js",
+							// A placeholder `afterChunks` overwrites for every entry it
+							// names; only a linked page keeps it, and it emits no JavaScript.
+							filename: compilation.outputOptions.chunkFilename || "[name].js",
 							dependOn: spec.dependOn
 						},
 						(err, entryModule) =>
@@ -800,6 +797,7 @@ class HtmlModulesPlugin {
 					collectEntrySpecs(module).map(async (spec) => {
 						const entryModule = await addEntry(spec);
 						if (entryModule && entryModule.type === HTML_MODULE_TYPE) {
+							linkedPages.set(spec.name, entryModule);
 							await processEntry(entryModule);
 						}
 					})
@@ -808,10 +806,14 @@ class HtmlModulesPlugin {
 			// Seed with the HTML modules seen during make (config entries /
 			// imports, fresh or cache-restored); linked pages are reached by
 			// recursion above. Sorted because they are tracked in build-completion
-			// order, and two pages sharing a basename are named by who comes first.
-			Promise.all(
-				[...htmlModules].sort(compareModulesByIdentifier).map(processEntry)
-			).then(() => callback(), callback);
+			// order, which the names must not depend on.
+			const seeds = [...htmlModules].sort(compareModulesByIdentifier);
+			Promise.all(seeds.map(processEntry)).then(() => {
+				/** @type {Set<Module>} */
+				const named = new Set();
+				for (const seed of seeds) recordNames(seed, named);
+				callback();
+			}, callback);
 		});
 
 		// `csp` injects a `<meta http-equiv="Content-Security-Policy">` and
@@ -993,29 +995,48 @@ class HtmlModulesPlugin {
 				// entry emits to a distinct file derived from `output.cssFilename`
 				// (or `output.cssChunkFilename` for non-initial CSS chunks).
 				compilation.hooks.afterChunks.tap(PLUGIN_NAME, () => {
-					const { stylesheetEntries, cssBaseNames, takenCssNames } =
-						getState(compilation);
-					if (cssBaseNames.size === 0) return;
+					const { stylesheetEntries, pendingNames } = getState(compilation);
+					if (pendingNames.size === 0) return;
 					const { chunkGraph, outputOptions } = compilation;
 					const cssTemplate = getNamedTemplate(
 						outputOptions.cssFilename,
 						".css"
 					);
-					for (const [entryName, base] of cssBaseNames) {
+					// Claimed in the order the pages recorded them, which is the
+					// documents' order rather than their builds'.
+					const takenJsNames = new Set(compilation.entries.keys());
+					const takenCssNames = new Set(takenJsNames);
+					for (const { freeName } of pendingNames.values()) {
+						if (freeName === undefined) continue;
+						// A page-only entry emits nothing of its own, so its name is free for
+						// the entries extracted from it — `app.html` keeps `app.js`.
+						takenJsNames.delete(freeName);
+						takenCssNames.delete(freeName);
+					}
+					for (const [entryName, { base, jsTemplate }] of pendingNames) {
 						const entrypoint = compilation.entrypoints.get(entryName);
 						if (!entrypoint) continue;
 						const chunk = entrypoint.getEntrypointChunk();
 						if (!chunk) continue;
+						// A stylesheet entry emits no JavaScript, so it claims no JS name and
+						// leaves that one to a `<script src>` of the same basename.
+						const emitsCss = stylesheetEntries.has(entryName);
+						if (!emitsCss) {
+							// `output.filename` named after the tag's url, the way an entry
+							// point is named. `Compilation` set it from the placeholder above.
+							chunk.filenameTemplate = jsTemplate.replace(
+								/\[name\]/g,
+								claimName(base, takenJsNames)
+							);
+						}
 						// A `<script src>` whose chunk carries no CSS claims no CSS name, so
 						// a `<link>` of the same basename still gets the plain one.
 						if (
-							!stylesheetEntries.has(entryName) &&
+							!emitsCss &&
 							!getCssModulesPlugin().chunkHasCss(chunk, chunkGraph)
 						) {
 							continue;
 						}
-						// Named after the tag's url through `output.cssFilename`, the way a
-						// CSS entry point is named.
 						chunk.cssFilenameTemplate = cssTemplate.replace(
 							/\[name\]/g,
 							claimName(base, takenCssNames)

--- a/lib/html/HtmlModulesPlugin.js
+++ b/lib/html/HtmlModulesPlugin.js
@@ -77,7 +77,6 @@ const getCssModulesPlugin = memoize(() => require("../css/CssModulesPlugin"));
 /** @import ChunkGraph from "../ChunkGraph" */
 /** @import Compiler from "../Compiler" */
 /** @import Module from "../Module" */
-/** @import ModuleGraph from "../ModuleGraph" */
 /** @import { ChunkFilenameTemplate } from "../Chunk" */
 /** @typedef {import("../Compilation").EntryData} EntryData */
 /** @import { HtmlModuleBuildInfo } from "./HtmlModule" */
@@ -292,9 +291,6 @@ const getPageOnlyEntry = (compilation, module) => {
 	return configured === undefined ? entry : undefined;
 };
 
-// The name a page lends when no file anywhere above it can name it.
-const DEFAULT_PAGE_NAME = "page";
-
 /**
  * The basename a tag's url lends to the entry it becomes, so
  * `src="./my-script.js"` emits `my-script.js`. Undefined for an inline body.
@@ -306,33 +302,6 @@ const getRequestBaseName = (request) => {
 	if (request.startsWith("data:")) return undefined;
 	const { path: file } = parseResource(request);
 	return basename(file, extname(file)) || undefined;
-};
-
-/**
- * The name a page lends to the entries it extracts from an inline body, which
- * has no url of its own: the page file's basename. A `data:` page is one
- * webpack writes, so it takes the name of the page embedding it — an
- * `<iframe srcdoc>` is named after the document carrying it.
- * @param {ModuleGraph} moduleGraph module graph
- * @param {Module} module html module
- * @param {Set<Module>} seen pages already asked, so an embedding cycle ends
- * @returns {string | undefined} the page's name, when a file backs it
- */
-const getPageFileName = (moduleGraph, module, seen) => {
-	const { resource } = /** @type {NormalModule} */ (module);
-	const own =
-		typeof resource === "string" ? getRequestBaseName(resource) : undefined;
-	if (own !== undefined) return own;
-	/** @type {string | undefined} */
-	let name;
-	for (const { dependency } of moduleGraph.getIncomingConnections(module)) {
-		const parent = dependency && moduleGraph.getParentModule(dependency);
-		if (!parent || seen.has(parent)) continue;
-		seen.add(parent);
-		name = getPageFileName(moduleGraph, parent, seen);
-		if (name !== undefined) break;
-	}
-	return name;
 };
 
 /**
@@ -750,8 +719,6 @@ class HtmlModulesPlugin {
 					module.buildInfo
 				);
 				if (!htmlEntries) return;
-				// An inline `<script>` has no url to be named after, so it borrows the
-				// page's name — its entry's name when the page is all that entry emits.
 				const pageEntry = getPageOnlyEntry(compilation, module);
 				const namedEntry =
 					pageEntry !== undefined && !extractedNames.has(pageEntry.name)
@@ -764,10 +731,6 @@ class HtmlModulesPlugin {
 					namedEntry !== undefined &&
 					typeof resource === "string" &&
 					resource.startsWith("data:text/html");
-				const pageName = namedEntry
-					? namedEntry.name
-					: getPageFileName(compilation.moduleGraph, module, new Set()) ||
-						DEFAULT_PAGE_NAME;
 				const { filename } = compilation.outputOptions;
 				// Kept as configured, a function included, and read for a name once the
 				// chunks exist.
@@ -788,9 +751,12 @@ class HtmlModulesPlugin {
 				}
 				ordered.sort((a, b) => a.index - b.index);
 				for (const entry of ordered) {
-					const base = wrapsEntry
-						? pageName
-						: getRequestBaseName(entry.request) || pageName;
+					// An inline `<script>` body has no url to be named after, so it
+					// keeps the name of its own entry, page hash and tag index.
+					const base =
+						wrapsEntry && namedEntry
+							? namedEntry.name
+							: getRequestBaseName(entry.request) || entry.entryName;
 					pendingNames.set(entry.entryName, {
 						base,
 						jsTemplate,
@@ -1043,6 +1009,12 @@ class HtmlModulesPlugin {
 					// documents' order rather than their builds'.
 					const takenJsNames = new Set(compilation.entries.keys());
 					const takenCssNames = new Set(takenJsNames);
+					// An extracted entry emits nothing under its own synthetic name, so
+					// that name never stands in the way of the one its tag asks for.
+					for (const entryName of pendingNames.keys()) {
+						takenJsNames.delete(entryName);
+						takenCssNames.delete(entryName);
+					}
 					for (const { freeName } of pendingNames.values()) {
 						if (freeName === undefined) continue;
 						// A page-only entry emits nothing of its own, so its name is free for

--- a/lib/html/HtmlModulesPlugin.js
+++ b/lib/html/HtmlModulesPlugin.js
@@ -21,7 +21,10 @@ const StaticExportsDependency = require("../dependencies/StaticExportsDependency
 const WebpackError = require("../errors/WebpackError");
 const JavascriptModulesPlugin = require("../javascript/JavascriptModulesPlugin");
 const ConcatenatedModule = require("../optimize/ConcatenatedModule");
-const { compareModulesByFullName } = require("../util/comparators");
+const {
+	compareModulesByFullName,
+	compareModulesByIdentifier
+} = require("../util/comparators");
 const createHash = require("../util/createHash");
 const createHooksRegistry = require("../util/createHooksRegistry");
 const {
@@ -51,6 +54,9 @@ const getHtmlParser = lazyModule(() => require("./HtmlParser"));
 // html generation only happens once a build actually has an html module
 const getHtmlGenerator = memoize(() => require("./HtmlGenerator"));
 
+// only reached once a page names a CSS chunk of its own
+const getCssModulesPlugin = memoize(() => require("../css/CssModulesPlugin"));
+
 /**
  * @import {
  * 	EntryDescriptionNormalized,
@@ -74,7 +80,7 @@ const getHtmlGenerator = memoize(() => require("./HtmlGenerator"));
 /** @typedef {import("../Compilation").EntryData} EntryData */
 /** @import { HtmlModuleBuildInfo } from "./HtmlModule" */
 /** @import HtmlParser from "./HtmlParser" */
-/** @typedef {{ request: string, entryName: string, type: "script" | "script-module" | "modulepreload" | "stylesheet" | "html" | "preload" | "prefetch", css?: boolean }} HtmlEntryInfo */
+/** @typedef {{ request: string, entryName: string, index: number, type: "script" | "script-module" | "modulepreload" | "stylesheet" | "html" | "preload" | "prefetch", css?: boolean }} HtmlEntryInfo */
 
 /** @typedef {{ outputName: string }} HtmlTransformHtmlContext */
 /** @typedef {{ outputName: string }} HtmlEmittedContext */
@@ -276,39 +282,89 @@ const getPageOnlyEntry = (compilation, module) => {
 	return configured === undefined ? entry : undefined;
 };
 
+// The name a page lends when it has no file of its own to be named after.
+const DEFAULT_PAGE_NAME = "page";
+
 /**
- * The name a page without an entry of its own lends to the entries extracted
- * from it: its file's basename, so a linked page reads as `about.js`.
+ * The name a page lends to the entries it extracts from an inline body, which
+ * has no url of its own: the page file's basename. Numbered when an entry or
+ * another page already holds it.
  * @param {Module} module html module
  * @param {Set<string>} taken names already spoken for in this compilation
- * @returns {string | undefined} the page's name, when it has one to lend
+ * @returns {string} the page's name
  */
 const getPageFileName = (module, taken) => {
 	const { resource } = /** @type {NormalModule} */ (module);
-	// A `data:` page is a wrapper webpack writes, and has no file to be named
-	// after; the entry it wraps names it instead.
-	if (typeof resource !== "string" || resource.startsWith("data:")) {
-		return undefined;
+	// A `data:` page is a wrapper webpack writes, with no file behind it.
+	let name = DEFAULT_PAGE_NAME;
+	if (typeof resource === "string" && !resource.startsWith("data:")) {
+		const { path: file } = parseResource(resource);
+		name = basename(file, extname(file)) || DEFAULT_PAGE_NAME;
 	}
-	const { path: file } = parseResource(resource);
-	const name = basename(file, extname(file));
-	// Two pages can share a basename, and one can match an entry — the first
-	// takes it and the rest keep their synthetic name.
-	if (name === "" || taken.has(name)) return undefined;
+	const base = name;
+	for (let index = 1; taken.has(name); index++) name = `${base}${index}`;
 	taken.add(name);
 	return name;
 };
 
 /**
- * A filename template usable for a page's extracted entries: it must name the
- * chunk, or every entry of the page would be emitted to the same file.
- * @param {import("../TemplatedPathPlugin").TemplatePath | FilenameTemplate | undefined} template configured template
- * @returns {string | undefined} the template, when it carries a `[name]`
+ * The basename a tag's url lends to the entry it becomes, so
+ * `src="./my-script.js"` emits `my-script.js`. Undefined for an inline body.
+ * @param {string} request the tag's request
+ * @returns {string | undefined} the basename, when the url carries one
  */
-const getNamedTemplate = (template) =>
-	typeof template === "string" && template.includes("[name]")
-		? template
-		: undefined;
+const getRequestBaseName = (request) => {
+	// An inline `<script>` body is a `data:` request webpack writes itself.
+	if (request.startsWith("data:")) return undefined;
+	const { path: file } = parseResource(request);
+	return basename(file, extname(file)) || undefined;
+};
+
+/**
+ * Claims `base`, numbering it while something else already emits under that
+ * name, so two tags sharing a basename stay distinct.
+ * @param {string} base preferred name
+ * @param {Set<string>} taken names this kind of output already emits under
+ * @returns {string} the claimed name
+ */
+const claimName = (base, taken) => {
+	let name = base;
+	for (let index = 1; taken.has(name); index++) name = `${base}${index}`;
+	taken.add(name);
+	return name;
+};
+
+// Placeholders that tell chunks apart on their own, so a template carrying
+// one needs no `[name]`. Not `[id]`: an extracted entry's id is synthetic.
+const CONTENT_PLACEHOLDER_REGEXP =
+	/\[(?:chunkhash|contenthash|fullhash|hash)[\]:]/;
+
+// Basename stem of a filename template — what `[name]` stands in for, keeping
+// the directory, extension and query the template asked for.
+const TEMPLATE_STEM_REGEXP = /(^|\/)[^/?]*?((?:\.[^./?]+)*)(\?.*)?$/;
+
+/**
+ * A filename template usable for a page's extracted entries: it must tell one
+ * entry from another, or every entry of the page would be emitted to the same
+ * file. A template naming neither the chunk nor its content lends its directory
+ * and extension to a `[name]` instead.
+ * @param {import("../TemplatedPathPlugin").TemplatePath | FilenameTemplate | undefined} template configured template
+ * @param {string} extension extension to fall back to when the template names none
+ * @returns {string} a template that tells the page's entries apart
+ */
+const getNamedTemplate = (template, extension) => {
+	if (typeof template !== "string") return `[name]${extension}`;
+	if (
+		template.includes("[name]") ||
+		CONTENT_PLACEHOLDER_REGEXP.test(template)
+	) {
+		return template;
+	}
+	return template.replace(
+		TEMPLATE_STEM_REGEXP,
+		(_, dir, ext, query) => `${dir}[name]${ext || extension}${query || ""}`
+	);
+};
 
 /**
  * Requests an `output.html` page must load for an entry: its `dependOn`
@@ -569,11 +625,11 @@ class HtmlModulesPlugin {
 		// `finishMake` creates their entries without scanning the whole module
 		// graph), the stylesheet entry names (read in `afterChunks`) and the html
 		// options of every emitted page, keyed by its asset name.
-		/** @type {WeakMap<import("../Compilation"), { htmlModules: Set<Module>, stylesheetEntries: Set<string>, cssFilenames: Map<string, string>, htmlAssetOptions: Map<string, OutputHtmlOptions> }>} */
+		/** @type {WeakMap<import("../Compilation"), { htmlModules: Set<Module>, stylesheetEntries: Set<string>, cssBaseNames: Map<string, string>, takenCssNames: Set<string>, htmlAssetOptions: Map<string, OutputHtmlOptions> }>} */
 		const compilationState = new WeakMap();
 		/**
 		 * @param {import("../Compilation")} compilation compilation
-		 * @returns {{ htmlModules: Set<Module>, stylesheetEntries: Set<string>, cssFilenames: Map<string, string>, htmlAssetOptions: Map<string, OutputHtmlOptions> }} per-compilation state
+		 * @returns {{ htmlModules: Set<Module>, stylesheetEntries: Set<string>, cssBaseNames: Map<string, string>, takenCssNames: Set<string>, htmlAssetOptions: Map<string, OutputHtmlOptions> }} per-compilation state
 		 */
 		const getState = (compilation) => {
 			let state = compilationState.get(compilation);
@@ -581,7 +637,8 @@ class HtmlModulesPlugin {
 				state = {
 					htmlModules: new Set(),
 					stylesheetEntries: new Set(),
-					cssFilenames: new Map(),
+					cssBaseNames: new Map(),
+					takenCssNames: new Set(),
 					htmlAssetOptions: new Map()
 				};
 				compilationState.set(compilation, state);
@@ -589,9 +646,13 @@ class HtmlModulesPlugin {
 			return state;
 		};
 		compiler.hooks.finishMake.tapAsync(PLUGIN_NAME, (compilation, callback) => {
-			const { htmlModules, stylesheetEntries, cssFilenames } =
+			const { htmlModules, stylesheetEntries, cssBaseNames, takenCssNames } =
 				getState(compilation);
 			const takenNames = new Set(compilation.entries.keys());
+			// A tag the browser loads directly is an entry point, so it can no more
+			// share an emitted name with another entry than two entries can.
+			const takenJsNames = new Set(takenNames);
+			for (const name of takenNames) takenCssNames.add(name);
 			/** @type {Set<string>} */
 			const extractedNames = new Set();
 
@@ -608,49 +669,67 @@ class HtmlModulesPlugin {
 				if (!htmlEntries) return [];
 				const context = /** @type {string} */ (module.context);
 				const specs = [];
-				// A page hands its name to the entries extracted from it, the way a
-				// JavaScript entry is named — it emits no JavaScript of its own.
+				// An inline `<script>` has no url to be named after, so it borrows the
+				// page's name — its entry's name when the page is all that entry emits.
 				const pageEntry = getPageOnlyEntry(compilation, module);
-				// A page the parser extracted from another one carries a synthetic
-				// entry name, so its file is the name a reader recognizes.
 				const namedEntry =
 					pageEntry !== undefined && !extractedNames.has(pageEntry.name)
 						? pageEntry
 						: undefined;
-				const pageName = namedEntry
-					? namedEntry.name
-					: getPageFileName(module, takenNames);
-				const { filename, cssFilename } = compilation.outputOptions;
+				// A page-only entry emits nothing of its own, so its name is free for
+				// the entries extracted from it — `app.html` keeps `app.js`.
+				if (namedEntry) {
+					takenJsNames.delete(namedEntry.name);
+					takenCssNames.delete(namedEntry.name);
+				}
+				// An `output.html` page is a wrapper webpack writes around an entry, so
+				// what it loads is that entry's own output and takes its name.
+				const wrapsEntry =
+					namedEntry !== undefined &&
+					typeof (/** @type {NormalModule} */ (module).resource) === "string" &&
+					/** @type {NormalModule} */ (module).resource.startsWith(
+						"data:text/html"
+					);
+				/** @type {string | undefined} */
+				let pageName;
+				const { filename, module: outputModule } = compilation.outputOptions;
 				const entryFilenameOption =
 					namedEntry && namedEntry.data.options.filename !== undefined
 						? namedEntry.data.options.filename
 						: filename;
-				const jsTemplate = pageName
-					? getNamedTemplate(entryFilenameOption)
-					: undefined;
-				const cssTemplate = pageName
-					? getNamedTemplate(cssFilename)
-					: undefined;
-				/**
-				 * @param {string} template filename template of the page's entry
-				 * @param {number} index position among the page's entries of that kind
-				 * @returns {string} filename template for one extracted entry
-				 */
-				const nameAfterPage = (template, index) => {
-					const name = /** @type {string} */ (pageName);
-					return template.replace(
-						/\[name\]/g,
-						index === 0 ? name : `${name}${index}`
-					);
-				};
-				// A script chunk's own `.css` sibling is named after the page too, so
-				// it starts counting where the page's stylesheet entries stop.
-				let styleIndex = 0;
-				let scriptIndex = 0;
-				let siblingStyleIndex = 0;
-				for (const group of Object.values(htmlEntries)) {
-					for (const entry of group) {
-						if (entry.type === "stylesheet" || entry.css) siblingStyleIndex++;
+				const jsTemplate = getNamedTemplate(
+					entryFilenameOption,
+					outputModule ? ".mjs" : ".js"
+				);
+				// Named in document order, so of two tags sharing a basename the first
+				// a reader sees keeps it. A linked page is named on emit instead.
+				/** @type {HtmlEntryInfo[]} */
+				const ordered = [];
+				for (const [groupKind, group] of Object.entries(htmlEntries)) {
+					if (groupKind === "html") continue;
+					for (const entry of group) ordered.push(entry);
+				}
+				ordered.sort((a, b) => a.index - b.index);
+				/** @type {Map<string, string>} */
+				const jsNames = new Map();
+				for (const entry of ordered) {
+					let base = wrapsEntry ? undefined : getRequestBaseName(entry.request);
+					if (base === undefined) {
+						if (pageName === undefined) {
+							pageName = namedEntry
+								? namedEntry.name
+								: getPageFileName(module, takenNames);
+						}
+						base = pageName;
+					}
+					cssBaseNames.set(entry.entryName, base);
+					// A stylesheet entry emits no JavaScript, so it claims no JS name and
+					// leaves that one to a `<script src>` of the same basename.
+					if (entry.type !== "stylesheet" && !entry.css) {
+						jsNames.set(
+							entry.entryName,
+							jsTemplate.replace(/\[name\]/g, claimName(base, takenJsNames))
+						);
 					}
 				}
 				for (const [groupKind, group] of Object.entries(htmlEntries)) {
@@ -672,35 +751,13 @@ class HtmlModulesPlugin {
 						if (emitsCss) {
 							stylesheetEntries.add(entry.entryName);
 						}
-						/** @type {string | undefined} */
-						let entryFilename;
-						// A linked page emits its file from `renderManifest`, so only the
-						// script and stylesheet entries take a name from the page.
-						if (groupKind !== "html") {
-							if (emitsCss) {
-								if (cssTemplate) {
-									cssFilenames.set(
-										entry.entryName,
-										nameAfterPage(cssTemplate, styleIndex++)
-									);
-								}
-							} else if (jsTemplate) {
-								entryFilename = nameAfterPage(jsTemplate, scriptIndex++);
-								if (cssTemplate) {
-									cssFilenames.set(
-										entry.entryName,
-										nameAfterPage(cssTemplate, siblingStyleIndex++)
-									);
-								}
-							}
-						}
 						extractedNames.add(entry.entryName);
 						specs.push({
 							context,
 							request: entry.request,
 							name: entry.entryName,
 							dependOn,
-							filename: entryFilename
+							filename: jsNames.get(entry.entryName)
 						});
 					}
 				}
@@ -717,8 +774,8 @@ class HtmlModulesPlugin {
 						EntryPlugin.createDependency(spec.request, { name: spec.name }),
 						{
 							name: spec.name,
-							// An entry not named after its page falls back to its synthetic
-							// name, so it can't collide with `output.filename`.
+							// Only a linked page arrives without a filename: it emits its
+							// markup from `renderManifest` and no JavaScript of its own.
 							filename:
 								spec.filename ||
 								compilation.outputOptions.chunkFilename ||
@@ -750,11 +807,11 @@ class HtmlModulesPlugin {
 			};
 			// Seed with the HTML modules seen during make (config entries /
 			// imports, fresh or cache-restored); linked pages are reached by
-			// recursion above.
-			Promise.all([...htmlModules].map(processEntry)).then(
-				() => callback(),
-				callback
-			);
+			// recursion above. Sorted because they are tracked in build-completion
+			// order, and two pages sharing a basename are named by who comes first.
+			Promise.all(
+				[...htmlModules].sort(compareModulesByIdentifier).map(processEntry)
+			).then(() => callback(), callback);
 		});
 
 		// `csp` injects a `<meta http-equiv="Content-Security-Policy">` and
@@ -936,33 +993,33 @@ class HtmlModulesPlugin {
 				// entry emits to a distinct file derived from `output.cssFilename`
 				// (or `output.cssChunkFilename` for non-initial CSS chunks).
 				compilation.hooks.afterChunks.tap(PLUGIN_NAME, () => {
-					const { stylesheetEntries, cssFilenames } = getState(compilation);
-					if (stylesheetEntries.size === 0 && cssFilenames.size === 0) return;
-					const cssEntries = new Set(stylesheetEntries);
-					for (const entryName of cssFilenames.keys()) {
-						cssEntries.add(entryName);
-					}
-					for (const entryName of cssEntries) {
+					const { stylesheetEntries, cssBaseNames, takenCssNames } =
+						getState(compilation);
+					if (cssBaseNames.size === 0) return;
+					const { chunkGraph, outputOptions } = compilation;
+					const cssTemplate = getNamedTemplate(
+						outputOptions.cssFilename,
+						".css"
+					);
+					for (const [entryName, base] of cssBaseNames) {
 						const entrypoint = compilation.entrypoints.get(entryName);
 						if (!entrypoint) continue;
 						const chunk = entrypoint.getEntrypointChunk();
 						if (!chunk) continue;
-						// Each html-derived stylesheet entry uses the
-						// `cssChunkFilename` template — even though the entry
-						// chunk technically `canBeInitial()`, we deliberately
-						// avoid `cssFilename` here because that template often
-						// has no per-entry placeholder (it's derived from
-						// `output.filename`, which can be a literal like
-						// `bundle0.js`), and multiple `<link rel="stylesheet">`
-						// tags would then collide on the same emitted `.css`
-						// file. `cssChunkFilename` is derived from
-						// `output.chunkFilename` which webpack auto-extends
-						// with `[id].` when needed, guaranteeing uniqueness.
-						// Every name here is either a stylesheet entry or one named
-						// after its page, so one of the two templates always applies.
-						chunk.cssFilenameTemplate =
-							cssFilenames.get(entryName) ||
-							compilation.outputOptions.cssChunkFilename;
+						// A `<script src>` whose chunk carries no CSS claims no CSS name, so
+						// a `<link>` of the same basename still gets the plain one.
+						if (
+							!stylesheetEntries.has(entryName) &&
+							!getCssModulesPlugin().chunkHasCss(chunk, chunkGraph)
+						) {
+							continue;
+						}
+						// Named after the tag's url through `output.cssFilename`, the way a
+						// CSS entry point is named.
+						chunk.cssFilenameTemplate = cssTemplate.replace(
+							/\[name\]/g,
+							claimName(base, takenCssNames)
+						);
 					}
 				});
 				compilation.dependencyTemplates.set(

--- a/lib/html/HtmlModulesPlugin.js
+++ b/lib/html/HtmlModulesPlugin.js
@@ -88,7 +88,7 @@ const getCssModulesPlugin = memoize(() => require("../css/CssModulesPlugin"));
  * every page is built, and resolved to filenames once chunks exist.
  * @typedef {object} PendingName
  * @property {string} base name the tag's url (or its page) asks for, before numbering
- * @property {FilenameTemplate | undefined} jsTemplate `output.filename` for this entry, as configured
+ * @property {FilenameTemplate} jsTemplate `output.filename` for this entry, as configured
  * @property {string=} freeName name of a page-only entry, which emits nothing and leaves it free
  */
 
@@ -319,20 +319,20 @@ const getRequestBaseName = (request) => {
  * @returns {string | undefined} the page's name, when a file backs it
  */
 const getPageFileName = (moduleGraph, module, seen) => {
-	if (seen.has(module)) return undefined;
-	seen.add(module);
 	const { resource } = /** @type {NormalModule} */ (module);
-	if (typeof resource === "string") {
-		const name = getRequestBaseName(resource);
-		if (name !== undefined) return name;
-	}
+	const own =
+		typeof resource === "string" ? getRequestBaseName(resource) : undefined;
+	if (own !== undefined) return own;
+	/** @type {string | undefined} */
+	let name;
 	for (const { dependency } of moduleGraph.getIncomingConnections(module)) {
-		if (!dependency) continue;
-		const parent = moduleGraph.getParentModule(dependency);
-		const name = parent && getPageFileName(moduleGraph, parent, seen);
-		if (name) return name;
+		const parent = dependency && moduleGraph.getParentModule(dependency);
+		if (!parent || seen.has(parent)) continue;
+		seen.add(parent);
+		name = getPageFileName(moduleGraph, parent, seen);
+		if (name !== undefined) break;
 	}
-	return undefined;
+	return name;
 };
 
 /**
@@ -365,12 +365,11 @@ const NAME_PLACEHOLDER_REGEXP = /\[name\]/g;
  * entry from another, or every entry of the page would be emitted to the same
  * file. A template naming neither the chunk nor its content lends its directory
  * and extension to a `[name]` instead.
- * @param {string | undefined} template configured template
+ * @param {string} template configured template
  * @param {string} extension extension to fall back to when the template names none
  * @returns {string} a template that tells the page's entries apart
  */
 const getNamedTemplate = (template, extension) => {
-	if (typeof template !== "string") return `[name]${extension}`;
 	if (
 		template.includes("[name]") ||
 		CONTENT_PLACEHOLDER_REGEXP.test(template)
@@ -386,7 +385,7 @@ const getNamedTemplate = (template, extension) => {
 /**
  * The filename one extracted entry emits under, with `name` filling the
  * `[name]` its template carries or the stem it leaves behind.
- * @param {string | undefined} template configured template
+ * @param {string} template configured template
  * @param {string} extension extension to fall back to when the template names none
  * @param {string} name the name this entry claimed
  * @returns {string} the entry's filename template
@@ -397,7 +396,7 @@ const fillNamedTemplate = (template, extension, name) =>
 /**
  * The same, for a template `output.filename` states as a function: it is called
  * at emit, and the path it returns read for a stem the same way.
- * @param {FilenameTemplate | undefined} template configured template
+ * @param {FilenameTemplate} template configured template
  * @param {string} extension extension to fall back to when the template names none
  * @param {string} name the name this entry claimed
  * @returns {ChunkFilenameTemplate} the entry's filename template

--- a/lib/html/HtmlModulesPlugin.js
+++ b/lib/html/HtmlModulesPlugin.js
@@ -77,6 +77,7 @@ const getCssModulesPlugin = memoize(() => require("../css/CssModulesPlugin"));
 /** @import ChunkGraph from "../ChunkGraph" */
 /** @import Compiler from "../Compiler" */
 /** @import Module from "../Module" */
+/** @import ModuleGraph from "../ModuleGraph" */
 /** @typedef {import("../Compilation").EntryData} EntryData */
 /** @import { HtmlModuleBuildInfo } from "./HtmlModule" */
 /** @import HtmlParser from "./HtmlParser" */
@@ -290,26 +291,8 @@ const getPageOnlyEntry = (compilation, module) => {
 	return configured === undefined ? entry : undefined;
 };
 
-// The name a page lends when it has no file of its own to be named after.
+// The name a page lends when no file anywhere above it can name it.
 const DEFAULT_PAGE_NAME = "page";
-
-/**
- * The name a page lends to the entries it extracts from an inline body, which
- * has no url of its own: the page file's basename. Numbered later, with every
- * other name, by `claimName`.
- * @param {Module} module html module
- * @returns {string} the page's name
- */
-const getPageFileName = (module) => {
-	const { resource } = /** @type {NormalModule} */ (module);
-	// A `data:` page is a wrapper webpack writes, with no file behind it.
-	if (typeof resource === "string" && !resource.startsWith("data:")) {
-		const { path: file } = parseResource(resource);
-		const name = basename(file, extname(file));
-		if (name !== "") return name;
-	}
-	return DEFAULT_PAGE_NAME;
-};
 
 /**
  * The basename a tag's url lends to the entry it becomes, so
@@ -322,6 +305,33 @@ const getRequestBaseName = (request) => {
 	if (request.startsWith("data:")) return undefined;
 	const { path: file } = parseResource(request);
 	return basename(file, extname(file)) || undefined;
+};
+
+/**
+ * The name a page lends to the entries it extracts from an inline body, which
+ * has no url of its own: the page file's basename. A `data:` page is one
+ * webpack writes, so it takes the name of the page embedding it — an
+ * `<iframe srcdoc>` is named after the document carrying it.
+ * @param {ModuleGraph} moduleGraph module graph
+ * @param {Module} module html module
+ * @param {Set<Module>} seen pages already asked, so an embedding cycle ends
+ * @returns {string | undefined} the page's name, when a file backs it
+ */
+const getPageFileName = (moduleGraph, module, seen) => {
+	if (seen.has(module)) return undefined;
+	seen.add(module);
+	const { resource } = /** @type {NormalModule} */ (module);
+	if (typeof resource === "string") {
+		const name = getRequestBaseName(resource);
+		if (name !== undefined) return name;
+	}
+	for (const { dependency } of moduleGraph.getIncomingConnections(module)) {
+		if (!dependency) continue;
+		const parent = moduleGraph.getParentModule(dependency);
+		const name = parent && getPageFileName(moduleGraph, parent, seen);
+		if (name) return name;
+	}
+	return undefined;
 };
 
 /**
@@ -725,7 +735,10 @@ class HtmlModulesPlugin {
 					namedEntry !== undefined &&
 					typeof resource === "string" &&
 					resource.startsWith("data:text/html");
-				const pageName = namedEntry ? namedEntry.name : getPageFileName(module);
+				const pageName = namedEntry
+					? namedEntry.name
+					: getPageFileName(compilation.moduleGraph, module, new Set()) ||
+						DEFAULT_PAGE_NAME;
 				const { filename, module: outputModule } = compilation.outputOptions;
 				const entryFilenameOption =
 					namedEntry && namedEntry.data.options.filename !== undefined

--- a/lib/html/HtmlModulesPlugin.js
+++ b/lib/html/HtmlModulesPlugin.js
@@ -78,6 +78,7 @@ const getCssModulesPlugin = memoize(() => require("../css/CssModulesPlugin"));
 /** @import Compiler from "../Compiler" */
 /** @import Module from "../Module" */
 /** @import ModuleGraph from "../ModuleGraph" */
+/** @import { ChunkFilenameTemplate } from "../Chunk" */
 /** @typedef {import("../Compilation").EntryData} EntryData */
 /** @import { HtmlModuleBuildInfo } from "./HtmlModule" */
 /** @import HtmlParser from "./HtmlParser" */
@@ -87,7 +88,7 @@ const getCssModulesPlugin = memoize(() => require("../css/CssModulesPlugin"));
  * every page is built, and resolved to filenames once chunks exist.
  * @typedef {object} PendingName
  * @property {string} base name the tag's url (or its page) asks for, before numbering
- * @property {string} jsTemplate `output.filename` for this entry, with a `[name]` to fill in
+ * @property {FilenameTemplate | undefined} jsTemplate `output.filename` for this entry, as configured
  * @property {string=} freeName name of a page-only entry, which emits nothing and leaves it free
  */
 
@@ -357,12 +358,14 @@ const CONTENT_PLACEHOLDER_REGEXP =
 // the directory, extension and query the template asked for.
 const TEMPLATE_STEM_REGEXP = /(^|\/)[^/?]*?((?:\.[^./?]+)*)(\?.*)?$/;
 
+const NAME_PLACEHOLDER_REGEXP = /\[name\]/g;
+
 /**
  * A filename template usable for a page's extracted entries: it must tell one
  * entry from another, or every entry of the page would be emitted to the same
  * file. A template naming neither the chunk nor its content lends its directory
  * and extension to a `[name]` instead.
- * @param {import("../TemplatedPathPlugin").TemplatePath | FilenameTemplate | undefined} template configured template
+ * @param {string | undefined} template configured template
  * @param {string} extension extension to fall back to when the template names none
  * @returns {string} a template that tells the page's entries apart
  */
@@ -378,6 +381,33 @@ const getNamedTemplate = (template, extension) => {
 		TEMPLATE_STEM_REGEXP,
 		(_, dir, ext, query) => `${dir}[name]${ext || extension}${query || ""}`
 	);
+};
+
+/**
+ * The filename one extracted entry emits under, with `name` filling the
+ * `[name]` its template carries or the stem it leaves behind.
+ * @param {string | undefined} template configured template
+ * @param {string} extension extension to fall back to when the template names none
+ * @param {string} name the name this entry claimed
+ * @returns {string} the entry's filename template
+ */
+const fillNamedTemplate = (template, extension, name) =>
+	getNamedTemplate(template, extension).replace(NAME_PLACEHOLDER_REGEXP, name);
+
+/**
+ * The same, for a template `output.filename` states as a function: it is called
+ * at emit, and the path it returns read for a stem the same way.
+ * @param {FilenameTemplate | undefined} template configured template
+ * @param {string} extension extension to fall back to when the template names none
+ * @param {string} name the name this entry claimed
+ * @returns {ChunkFilenameTemplate} the entry's filename template
+ */
+const getEntryTemplate = (template, extension, name) => {
+	if (typeof template === "function") {
+		return (pathData, assetInfo) =>
+			fillNamedTemplate(template(pathData, assetInfo), extension, name);
+	}
+	return fillNamedTemplate(template, extension, name);
 };
 
 /**
@@ -739,15 +769,13 @@ class HtmlModulesPlugin {
 					? namedEntry.name
 					: getPageFileName(compilation.moduleGraph, module, new Set()) ||
 						DEFAULT_PAGE_NAME;
-				const { filename, module: outputModule } = compilation.outputOptions;
-				const entryFilenameOption =
+				const { filename } = compilation.outputOptions;
+				// Kept as configured, a function included, and read for a name once the
+				// chunks exist.
+				const jsTemplate =
 					namedEntry && namedEntry.data.options.filename !== undefined
 						? namedEntry.data.options.filename
 						: filename;
-				const jsTemplate = getNamedTemplate(
-					entryFilenameOption,
-					outputModule ? ".mjs" : ".js"
-				);
 				// In document order, so of two tags sharing a basename the first a
 				// reader sees keeps it. A linked page is named on emit instead.
 				/** @type {HtmlEntryInfo[]} */
@@ -1011,10 +1039,7 @@ class HtmlModulesPlugin {
 					const { stylesheetEntries, pendingNames } = getState(compilation);
 					if (pendingNames.size === 0) return;
 					const { chunkGraph, outputOptions } = compilation;
-					const cssTemplate = getNamedTemplate(
-						outputOptions.cssFilename,
-						".css"
-					);
+					const jsExtension = outputOptions.module ? ".mjs" : ".js";
 					// Claimed in the order the pages recorded them, which is the
 					// documents' order rather than their builds'.
 					const takenJsNames = new Set(compilation.entries.keys());
@@ -1037,8 +1062,9 @@ class HtmlModulesPlugin {
 						if (!emitsCss) {
 							// `output.filename` named after the tag's url, the way an entry
 							// point is named. `Compilation` set it from the placeholder above.
-							chunk.filenameTemplate = jsTemplate.replace(
-								/\[name\]/g,
+							chunk.filenameTemplate = getEntryTemplate(
+								jsTemplate,
+								jsExtension,
 								claimName(base, takenJsNames)
 							);
 						}
@@ -1050,8 +1076,9 @@ class HtmlModulesPlugin {
 						) {
 							continue;
 						}
-						chunk.cssFilenameTemplate = cssTemplate.replace(
-							/\[name\]/g,
+						chunk.cssFilenameTemplate = getEntryTemplate(
+							outputOptions.cssFilename,
+							".css",
 							claimName(base, takenCssNames)
 						);
 					}

--- a/lib/html/HtmlParser.js
+++ b/lib/html/HtmlParser.js
@@ -868,6 +868,7 @@ class HtmlParser extends Parser {
 		 * @typedef {object} HtmlEntryInfo
 		 * @property {string} request
 		 * @property {string} entryName
+		 * @property {number} index position in the document, across all groups — the order the emitted files are named in
 		 * @property {"script" | "script-module" | "modulepreload" | "stylesheet" | "html" | "preload" | "prefetch"} type
 		 * @property {boolean=} css entry emits a CSS chunk (`<link rel="preload" as="style">`), so it needs the CSS filename template
 		 */
@@ -1478,7 +1479,8 @@ class HtmlParser extends Parser {
 										const scriptType =
 											/** @type {"script" | "script-module"} */ (type);
 										const request = dataUri("text/javascript", value);
-										const entryName = `__html_${moduleHash}_${nextEntryIndex++}`;
+										const index = nextEntryIndex++;
+										const entryName = `__html_${moduleHash}_${index}`;
 										const dep = new HtmlInlineScriptDependency(
 											request,
 											nameEnd,
@@ -1501,6 +1503,7 @@ class HtmlParser extends Parser {
 										).push({
 											request,
 											entryName,
+											index,
 											type: scriptType
 										});
 										break;
@@ -1581,7 +1584,8 @@ class HtmlParser extends Parser {
 										// kind rewrites to the page's filename and emits no sibling tags.
 										// Recorded as an independent entry (no `dependOn`), like an entry point.
 										if (type === "html") {
-											const entryName = `__html_${moduleHash}_${nextEntryIndex++}`;
+											const index = nextEntryIndex++;
+											const entryName = `__html_${moduleHash}_${index}`;
 											const dep = new HtmlEntryDependency(
 												request,
 												[s, e],
@@ -1591,7 +1595,7 @@ class HtmlParser extends Parser {
 											);
 											setLoc(dep, s, e);
 											module.addPresentationalDependency(dep);
-											htmlLinkEntries.push({ request, entryName, type });
+											htmlLinkEntries.push({ request, entryName, index, type });
 											continue;
 										}
 										// `rel="preload"/"prefetch"` of a bundled resource: an
@@ -1603,7 +1607,8 @@ class HtmlParser extends Parser {
 											const asStyle = as
 												? as.trim().toLowerCase() === "style"
 												: false;
-											const entryName = `__html_${moduleHash}_${nextEntryIndex++}`;
+											const index = nextEntryIndex++;
+											const entryName = `__html_${moduleHash}_${index}`;
 											// Tag metadata so the template can mirror `crossorigin`/
 											// `integrity` onto a native `preload` `<link>` (integrity-
 											// eligible per the SRI spec). `prefetch` gets none — the spec
@@ -1635,6 +1640,7 @@ class HtmlParser extends Parser {
 											).push({
 												request,
 												entryName,
+												index,
 												type,
 												css: asStyle
 											});
@@ -1649,7 +1655,8 @@ class HtmlParser extends Parser {
 											type === "modulepreload" ||
 											type === "stylesheet"
 										) {
-											const entryName = `__html_${moduleHash}_${nextEntryIndex++}`;
+											const index = nextEntryIndex++;
+											const entryName = `__html_${moduleHash}_${index}`;
 											const willBeModuleScript =
 												type === "script-module" ||
 												(outputModule && type === "script");
@@ -1777,7 +1784,7 @@ class HtmlParser extends Parser {
 													: type === "stylesheet"
 														? stylesheetEntries
 														: modulePreloadEntries
-											).push({ request, entryName, type });
+											).push({ request, entryName, index, type });
 										} else {
 											const dep = new HtmlSourceDependency(request, [s, e]);
 											ResourceHintPlugin.applyDefaults(

--- a/test/HtmlParser.unittest.js
+++ b/test/HtmlParser.unittest.js
@@ -139,6 +139,7 @@ describe("HtmlParser", () => {
 				{
 					request: dependency.request,
 					entryName: dependency.entryName,
+					index: 0,
 					type: "script"
 				}
 			],

--- a/test/configCases/embedded/everything/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/embedded/everything/__snapshots__/ConfigCacheTest.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`ConfigCacheTestCases embedded everything exported tests extracts the script of an html entry into a chunk of its own 1`] = `"<script src=page.js>"`;
+exports[`ConfigCacheTestCases embedded everything exported tests extracts the script of an html entry into a chunk of its own 1`] = `"<script src=__html_2a0885fc_0.js>"`;
 
 exports[`ConfigCacheTestCases embedded everything exported tests leaves a css data url whose media type names no language 1`] = `".png{background:url(data:image/png;base64,AAAA)}"`;
 
@@ -44,7 +44,7 @@ Array [
 `;
 
 exports[`ConfigCacheTestCases embedded everything exported tests minifies an html document imported into javascript 1`] = `
-"<!doctype html><html lang=en><head><title>module</title><style>.moduleStyle{background:url(\\"data:image/svg+xml,<svg> <rect fill='red' /> </svg>\\");color:red}</style><script src=page-module.js></script><script type=application/json>{\\"moduleJson\\":1}</script></head><body>
+"<!doctype html><html lang=en><head><title>module</title><style>.moduleStyle{background:url(\\"data:image/svg+xml,<svg> <rect fill='red' /> </svg>\\");color:red}</style><script src=__html_fc45afb8_0.js></script><script type=application/json>{\\"moduleJson\\":1}</script></head><body>
 <p style=color:#0f0>hi</p>
 <svg viewBox=\\"0 0 2 2\\"> <rect fill=red /> </svg>
 <iframe srcdoc=\\"<style>.moduleSrcdoc{color:#00f}</style>\\"></iframe>
@@ -62,7 +62,7 @@ exports[`ConfigCacheTestCases embedded everything exported tests minifies an htm
 `;
 
 exports[`ConfigCacheTestCases embedded everything exported tests minifies an html document webpack parses as an entry 1`] = `
-"<!doctype html><html lang=en><head><title>entry</title><style>.entryStyle{background:url(\\"data:image/svg+xml,<svg> <rect fill='red' /> </svg>\\");color:red}</style><script src=page.js></script><script type=application/json>{\\"entryJson\\":1}</script></head><body>
+"<!doctype html><html lang=en><head><title>entry</title><style>.entryStyle{background:url(\\"data:image/svg+xml,<svg> <rect fill='red' /> </svg>\\");color:red}</style><script src=__html_2a0885fc_0.js></script><script type=application/json>{\\"entryJson\\":1}</script></head><body>
 <p style=color:#0f0>hi</p>
 <svg viewBox=\\"0 0 2 2\\"> <rect fill=red /> </svg>
 <iframe srcdoc=\\"<style>.entrySrcdoc{color:#00f}</style>\\"></iframe>

--- a/test/configCases/embedded/everything/__snapshots__/ConfigTest.snap
+++ b/test/configCases/embedded/everything/__snapshots__/ConfigTest.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`ConfigTestCases embedded everything exported tests extracts the script of an html entry into a chunk of its own 1`] = `"<script src=page.js>"`;
+exports[`ConfigTestCases embedded everything exported tests extracts the script of an html entry into a chunk of its own 1`] = `"<script src=__html_2a0885fc_0.js>"`;
 
 exports[`ConfigTestCases embedded everything exported tests leaves a css data url whose media type names no language 1`] = `".png{background:url(data:image/png;base64,AAAA)}"`;
 
@@ -44,7 +44,7 @@ Array [
 `;
 
 exports[`ConfigTestCases embedded everything exported tests minifies an html document imported into javascript 1`] = `
-"<!doctype html><html lang=en><head><title>module</title><style>.moduleStyle{background:url(\\"data:image/svg+xml,<svg> <rect fill='red' /> </svg>\\");color:red}</style><script src=page-module.js></script><script type=application/json>{\\"moduleJson\\":1}</script></head><body>
+"<!doctype html><html lang=en><head><title>module</title><style>.moduleStyle{background:url(\\"data:image/svg+xml,<svg> <rect fill='red' /> </svg>\\");color:red}</style><script src=__html_fc45afb8_0.js></script><script type=application/json>{\\"moduleJson\\":1}</script></head><body>
 <p style=color:#0f0>hi</p>
 <svg viewBox=\\"0 0 2 2\\"> <rect fill=red /> </svg>
 <iframe srcdoc=\\"<style>.moduleSrcdoc{color:#00f}</style>\\"></iframe>
@@ -62,7 +62,7 @@ exports[`ConfigTestCases embedded everything exported tests minifies an html doc
 `;
 
 exports[`ConfigTestCases embedded everything exported tests minifies an html document webpack parses as an entry 1`] = `
-"<!doctype html><html lang=en><head><title>entry</title><style>.entryStyle{background:url(\\"data:image/svg+xml,<svg> <rect fill='red' /> </svg>\\");color:red}</style><script src=page.js></script><script type=application/json>{\\"entryJson\\":1}</script></head><body>
+"<!doctype html><html lang=en><head><title>entry</title><style>.entryStyle{background:url(\\"data:image/svg+xml,<svg> <rect fill='red' /> </svg>\\");color:red}</style><script src=__html_2a0885fc_0.js></script><script type=application/json>{\\"entryJson\\":1}</script></head><body>
 <p style=color:#0f0>hi</p>
 <svg viewBox=\\"0 0 2 2\\"> <rect fill=red /> </svg>
 <iframe srcdoc=\\"<style>.entrySrcdoc{color:#00f}</style>\\"></iframe>

--- a/test/configCases/html/basic/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/basic/__snapshots__/ConfigCacheTest.snap
@@ -23,7 +23,7 @@ exports[`ConfigCacheTestCases html basic exported tests should compile and expor
 	<li>Milk</li>
 </ol>
 
-<script src=\\"117.bundle0.js\\"></script>
+<script src=\\"page.js\\"></script>
 
 <!-- comment -->
 
@@ -34,7 +34,7 @@ exports[`ConfigCacheTestCases html basic exported tests should compile and expor
 
 <input type=\\"text\\" />
 
-<script src=\\"308.bundle0.js\\"></script>
+<script src=\\"page1.js\\"></script>
 
 <picture>
 	<source media=\\"(min-width: 650px)\\" srcset=\\"31d6cfe0d16ae931b73c.png\\">
@@ -103,8 +103,8 @@ or
 <p >Text</p>
 <p   >Text</p>
 
-<script src=\\"319.bundle0.js\\"></script>
-<script src=\\"510.bundle0.js\\"></script>
+<script src=\\"page2.js\\"></script>
+<script src=\\"page3.js\\"></script>
 
 <img src=\\"#hash\\" />
 <img src='31d6cfe0d16ae931b73c.png#hash' />

--- a/test/configCases/html/basic/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/basic/__snapshots__/ConfigCacheTest.snap
@@ -23,7 +23,7 @@ exports[`ConfigCacheTestCases html basic exported tests should compile and expor
 	<li>Milk</li>
 </ol>
 
-<script src=\\"page.js\\"></script>
+<script src=\\"__html_cbe5b59d_0.js\\"></script>
 
 <!-- comment -->
 
@@ -34,7 +34,7 @@ exports[`ConfigCacheTestCases html basic exported tests should compile and expor
 
 <input type=\\"text\\" />
 
-<script src=\\"page1.js\\"></script>
+<script src=\\"__html_cbe5b59d_1.js\\"></script>
 
 <picture>
 	<source media=\\"(min-width: 650px)\\" srcset=\\"31d6cfe0d16ae931b73c.png\\">
@@ -103,8 +103,8 @@ or
 <p >Text</p>
 <p   >Text</p>
 
-<script src=\\"page2.js\\"></script>
-<script src=\\"page3.js\\"></script>
+<script src=\\"__html_cbe5b59d_2.js\\"></script>
+<script src=\\"__html_cbe5b59d_3.js\\"></script>
 
 <img src=\\"#hash\\" />
 <img src='31d6cfe0d16ae931b73c.png#hash' />

--- a/test/configCases/html/basic/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/basic/__snapshots__/ConfigTest.snap
@@ -23,7 +23,7 @@ exports[`ConfigTestCases html basic exported tests should compile and export htm
 	<li>Milk</li>
 </ol>
 
-<script src=\\"page.js\\"></script>
+<script src=\\"__html_cbe5b59d_0.js\\"></script>
 
 <!-- comment -->
 
@@ -34,7 +34,7 @@ exports[`ConfigTestCases html basic exported tests should compile and export htm
 
 <input type=\\"text\\" />
 
-<script src=\\"page1.js\\"></script>
+<script src=\\"__html_cbe5b59d_1.js\\"></script>
 
 <picture>
 	<source media=\\"(min-width: 650px)\\" srcset=\\"31d6cfe0d16ae931b73c.png\\">
@@ -103,8 +103,8 @@ or
 <p >Text</p>
 <p   >Text</p>
 
-<script src=\\"page2.js\\"></script>
-<script src=\\"page3.js\\"></script>
+<script src=\\"__html_cbe5b59d_2.js\\"></script>
+<script src=\\"__html_cbe5b59d_3.js\\"></script>
 
 <img src=\\"#hash\\" />
 <img src='31d6cfe0d16ae931b73c.png#hash' />

--- a/test/configCases/html/basic/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/basic/__snapshots__/ConfigTest.snap
@@ -23,7 +23,7 @@ exports[`ConfigTestCases html basic exported tests should compile and export htm
 	<li>Milk</li>
 </ol>
 
-<script src=\\"117.bundle0.js\\"></script>
+<script src=\\"page.js\\"></script>
 
 <!-- comment -->
 
@@ -34,7 +34,7 @@ exports[`ConfigTestCases html basic exported tests should compile and export htm
 
 <input type=\\"text\\" />
 
-<script src=\\"308.bundle0.js\\"></script>
+<script src=\\"page1.js\\"></script>
 
 <picture>
 	<source media=\\"(min-width: 650px)\\" srcset=\\"31d6cfe0d16ae931b73c.png\\">
@@ -103,8 +103,8 @@ or
 <p >Text</p>
 <p   >Text</p>
 
-<script src=\\"319.bundle0.js\\"></script>
-<script src=\\"510.bundle0.js\\"></script>
+<script src=\\"page2.js\\"></script>
+<script src=\\"page3.js\\"></script>
 
 <img src=\\"#hash\\" />
 <img src='31d6cfe0d16ae931b73c.png#hash' />

--- a/test/configCases/html/css-imported-from-js/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/css-imported-from-js/__snapshots__/ConfigCacheTest.snap
@@ -5,7 +5,7 @@ exports[`ConfigCacheTestCases html css-imported-from-js exported tests should em
 <html>
 <head>
 <title>HTML entry with JS that imports CSS</title>
-<script src=\\"page.js\\" nonce=\\"test-nonce\\" crossorigin=\\"anonymous\\" referrerpolicy=\\"origin\\" defer integrity=\\"sha384-IGNOREME\\"></script><link rel=\\"stylesheet\\" href=\\"page.css\\" nonce=\\"test-nonce\\" crossorigin=\\"anonymous\\" referrerpolicy=\\"origin\\">
+<script src=\\"entry.js\\" nonce=\\"test-nonce\\" crossorigin=\\"anonymous\\" referrerpolicy=\\"origin\\" defer integrity=\\"sha384-IGNOREME\\"></script><link rel=\\"stylesheet\\" href=\\"entry.css\\" nonce=\\"test-nonce\\" crossorigin=\\"anonymous\\" referrerpolicy=\\"origin\\">
 </head>
 <body><div class=\\"hero\\">Box</div></body>
 </html>

--- a/test/configCases/html/css-imported-from-js/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/css-imported-from-js/__snapshots__/ConfigTest.snap
@@ -5,7 +5,7 @@ exports[`ConfigTestCases html css-imported-from-js exported tests should emit a 
 <html>
 <head>
 <title>HTML entry with JS that imports CSS</title>
-<script src=\\"page.js\\" nonce=\\"test-nonce\\" crossorigin=\\"anonymous\\" referrerpolicy=\\"origin\\" defer integrity=\\"sha384-IGNOREME\\"></script><link rel=\\"stylesheet\\" href=\\"page.css\\" nonce=\\"test-nonce\\" crossorigin=\\"anonymous\\" referrerpolicy=\\"origin\\">
+<script src=\\"entry.js\\" nonce=\\"test-nonce\\" crossorigin=\\"anonymous\\" referrerpolicy=\\"origin\\" defer integrity=\\"sha384-IGNOREME\\"></script><link rel=\\"stylesheet\\" href=\\"entry.css\\" nonce=\\"test-nonce\\" crossorigin=\\"anonymous\\" referrerpolicy=\\"origin\\">
 </head>
 <body><div class=\\"hero\\">Box</div></body>
 </html>

--- a/test/configCases/html/css-mixed-link-and-js-import/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/css-mixed-link-and-js-import/__snapshots__/ConfigCacheTest.snap
@@ -5,8 +5,8 @@ exports[`ConfigCacheTestCases html css-mixed-link-and-js-import exported tests s
 <html>
 <head>
 <title>Mixed: link stylesheet + JS-imported CSS</title>
-<link rel=\\"stylesheet\\" href=\\"page.css\\">
-<link rel=\\"stylesheet\\" href=\\"page1.css\\"><script src=\\"page.js\\"></script>
+<link rel=\\"stylesheet\\" href=\\"linked.css\\">
+<link rel=\\"stylesheet\\" href=\\"entry.css\\"><script src=\\"entry.js\\"></script>
 </head>
 <body><div class=\\"hero\\">Box</div></body>
 </html>

--- a/test/configCases/html/css-mixed-link-and-js-import/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/css-mixed-link-and-js-import/__snapshots__/ConfigTest.snap
@@ -5,8 +5,8 @@ exports[`ConfigTestCases html css-mixed-link-and-js-import exported tests should
 <html>
 <head>
 <title>Mixed: link stylesheet + JS-imported CSS</title>
-<link rel=\\"stylesheet\\" href=\\"page.css\\">
-<link rel=\\"stylesheet\\" href=\\"page1.css\\"><script src=\\"page.js\\"></script>
+<link rel=\\"stylesheet\\" href=\\"linked.css\\">
+<link rel=\\"stylesheet\\" href=\\"entry.css\\"><script src=\\"entry.js\\"></script>
 </head>
 <body><div class=\\"hero\\">Box</div></body>
 </html>

--- a/test/configCases/html/css-runtime-and-split-chunks/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/css-runtime-and-split-chunks/__snapshots__/ConfigCacheTest.snap
@@ -5,7 +5,7 @@ exports[`ConfigCacheTestCases html css-runtime-and-split-chunks exported tests s
 <html>
 <head>
 <title>HTML entry with runtimeChunk + splitChunks + JS-imported CSS</title>
-<link rel=\\"stylesheet\\" href=\\"page.css\\"><script src=\\"html-runtime.js\\"></script><script src=\\"vendor.js\\"></script><script src=\\"page.js\\"></script>
+<link rel=\\"stylesheet\\" href=\\"entry.css\\"><script src=\\"html-runtime.js\\"></script><script src=\\"vendor.js\\"></script><script src=\\"entry.js\\"></script>
 </head>
 <body><div class=\\"hero\\">Box</div></body>
 </html>

--- a/test/configCases/html/css-runtime-and-split-chunks/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/css-runtime-and-split-chunks/__snapshots__/ConfigTest.snap
@@ -5,7 +5,7 @@ exports[`ConfigTestCases html css-runtime-and-split-chunks exported tests should
 <html>
 <head>
 <title>HTML entry with runtimeChunk + splitChunks + JS-imported CSS</title>
-<link rel=\\"stylesheet\\" href=\\"page.css\\"><script src=\\"html-runtime.js\\"></script><script src=\\"vendor.js\\"></script><script src=\\"page.js\\"></script>
+<link rel=\\"stylesheet\\" href=\\"entry.css\\"><script src=\\"html-runtime.js\\"></script><script src=\\"vendor.js\\"></script><script src=\\"entry.js\\"></script>
 </head>
 <body><div class=\\"hero\\">Box</div></body>
 </html>

--- a/test/configCases/html/css-split-chunks-order/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/css-split-chunks-order/__snapshots__/ConfigCacheTest.snap
@@ -5,7 +5,7 @@ exports[`ConfigCacheTestCases html css-split-chunks-order exported tests should 
 <html>
 <head>
 <title>HTML entry with split CSS chunks</title>
-<link rel=\\"stylesheet\\" href=\\"style1.css\\"><link rel=\\"stylesheet\\" href=\\"style2.css\\"><script src=\\"page.js\\"></script>
+<link rel=\\"stylesheet\\" href=\\"style1.css\\"><link rel=\\"stylesheet\\" href=\\"style2.css\\"><script src=\\"entry.js\\"></script>
 </head>
 <body><div class=\\"hero\\">Box</div></body>
 </html>

--- a/test/configCases/html/css-split-chunks-order/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/css-split-chunks-order/__snapshots__/ConfigTest.snap
@@ -5,7 +5,7 @@ exports[`ConfigTestCases html css-split-chunks-order exported tests should refer
 <html>
 <head>
 <title>HTML entry with split CSS chunks</title>
-<link rel=\\"stylesheet\\" href=\\"style1.css\\"><link rel=\\"stylesheet\\" href=\\"style2.css\\"><script src=\\"page.js\\"></script>
+<link rel=\\"stylesheet\\" href=\\"style1.css\\"><link rel=\\"stylesheet\\" href=\\"style2.css\\"><script src=\\"entry.js\\"></script>
 </head>
 <body><div class=\\"hero\\">Box</div></body>
 </html>

--- a/test/configCases/html/entry-script-and-stylesheet/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/entry-script-and-stylesheet/__snapshots__/ConfigCacheTest.snap
@@ -5,8 +5,8 @@ exports[`ConfigCacheTestCases html entry-script-and-stylesheet exported tests sh
 <html>
 <head>
 <title>HTML entry with script and stylesheet</title>
-<link rel=\\"stylesheet\\" href=\\"page.css\\">
-<script src=\\"page.js\\"></script>
+<link rel=\\"stylesheet\\" href=\\"styles.css\\">
+<script src=\\"app.js\\"></script>
 </head>
 <body>
 <h1>Hello</h1>

--- a/test/configCases/html/entry-script-and-stylesheet/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/entry-script-and-stylesheet/__snapshots__/ConfigTest.snap
@@ -5,8 +5,8 @@ exports[`ConfigTestCases html entry-script-and-stylesheet exported tests should 
 <html>
 <head>
 <title>HTML entry with script and stylesheet</title>
-<link rel=\\"stylesheet\\" href=\\"page.css\\">
-<script src=\\"page.js\\"></script>
+<link rel=\\"stylesheet\\" href=\\"styles.css\\">
+<script src=\\"app.js\\"></script>
 </head>
 <body>
 <h1>Hello</h1>

--- a/test/configCases/html/extract-runtime-chunk/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/extract-runtime-chunk/__snapshots__/ConfigCacheTest.snap
@@ -5,14 +5,14 @@ exports[`ConfigCacheTestCases html extract-runtime-chunk exported tests should l
 <html>
 <head>
 <title>Extracted HTML with runtime chunk</title>
-<script src=\\"html-runtime.js\\" nonce=\\"abc\\" crossorigin=\\"anonymous\\"></script><script src=\\"page.js\\" nonce=\\"abc\\" crossorigin=\\"anonymous\\" integrity=\\"sha384-IGNOREME\\"></script>
+<script src=\\"html-runtime.js\\" nonce=\\"abc\\" crossorigin=\\"anonymous\\"></script><script src=\\"entry.js\\" nonce=\\"abc\\" crossorigin=\\"anonymous\\" integrity=\\"sha384-IGNOREME\\"></script>
 </head>
 <body>
 <h1>Hello</h1>
 <!-- A second classic <script src> chains via dependOn to the first. The
      shared runtime chunk is already loaded by the leader's tag above, so
      this tag must NOT prepend another runtime <script> for itself. -->
-<script src=\\"page1.js\\"></script>
+<script src=\\"other.js\\"></script>
 </body>
 </html>
 "

--- a/test/configCases/html/extract-runtime-chunk/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/extract-runtime-chunk/__snapshots__/ConfigTest.snap
@@ -5,14 +5,14 @@ exports[`ConfigTestCases html extract-runtime-chunk exported tests should load t
 <html>
 <head>
 <title>Extracted HTML with runtime chunk</title>
-<script src=\\"html-runtime.js\\" nonce=\\"abc\\" crossorigin=\\"anonymous\\"></script><script src=\\"page.js\\" nonce=\\"abc\\" crossorigin=\\"anonymous\\" integrity=\\"sha384-IGNOREME\\"></script>
+<script src=\\"html-runtime.js\\" nonce=\\"abc\\" crossorigin=\\"anonymous\\"></script><script src=\\"entry.js\\" nonce=\\"abc\\" crossorigin=\\"anonymous\\" integrity=\\"sha384-IGNOREME\\"></script>
 </head>
 <body>
 <h1>Hello</h1>
 <!-- A second classic <script src> chains via dependOn to the first. The
      shared runtime chunk is already loaded by the leader's tag above, so
      this tag must NOT prepend another runtime <script> for itself. -->
-<script src=\\"page1.js\\"></script>
+<script src=\\"other.js\\"></script>
 </body>
 </html>
 "

--- a/test/configCases/html/extract-runtime-chunk/index.js
+++ b/test/configCases/html/extract-runtime-chunk/index.js
@@ -22,8 +22,8 @@ it("should load the shared runtime chunk exactly once even when multiple <script
 	// and overwrite the leader's module registry.
 	expect(runtimeRefs).toHaveLength(1);
 	expect(scriptSrcMatches[0]).toContain("html-runtime");
-	expect(scriptSrcMatches[1]).toMatch(/page\.js/);
-	expect(scriptSrcMatches[2]).toMatch(/page1\.js/);
+	expect(scriptSrcMatches[1]).toMatch(/entry\.js/);
+	expect(scriptSrcMatches[2]).toMatch(/other\.js/);
 	// All referenced chunks were emitted to disk.
 	expect(readFile(scriptSrcMatches[0])).toContain("__webpack_require__");
 	expect(readFile(scriptSrcMatches[1])).toContain('module.exports = "entry"');
@@ -49,6 +49,6 @@ it("should propagate safe attributes onto the sibling runtime <script> tag and d
 	);
 	// The original entry tag keeps its own integrity attribute untouched.
 	expect(extracted).toMatch(
-		/<script[^>]*\bsrc="[^"]*page\d*\.js"[^>]*\bintegrity="sha384-IGNOREME"/
+		/<script[^>]*\bsrc="entry\.js"[^>]*\bintegrity="sha384-IGNOREME"/
 	);
 });

--- a/test/configCases/html/extract-split-chunks/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/extract-split-chunks/__snapshots__/ConfigCacheTest.snap
@@ -5,7 +5,7 @@ exports[`ConfigCacheTestCases html extract-split-chunks exported tests should re
 <html>
 <head>
 <title>Extracted HTML with split chunks</title>
-<script src=\\"vendor.js\\"></script><script src=\\"page.js\\"></script>
+<script src=\\"vendor.js\\"></script><script src=\\"entry.js\\"></script>
 </head>
 <body>
 <h1>Hello</h1>

--- a/test/configCases/html/extract-split-chunks/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/extract-split-chunks/__snapshots__/ConfigTest.snap
@@ -5,7 +5,7 @@ exports[`ConfigTestCases html extract-split-chunks exported tests should referen
 <html>
 <head>
 <title>Extracted HTML with split chunks</title>
-<script src=\\"vendor.js\\"></script><script src=\\"page.js\\"></script>
+<script src=\\"vendor.js\\"></script><script src=\\"entry.js\\"></script>
 </head>
 <body>
 <h1>Hello</h1>

--- a/test/configCases/html/extract-split-chunks/index.js
+++ b/test/configCases/html/extract-split-chunks/index.js
@@ -18,7 +18,7 @@ it("should reference both the split-out vendor chunk and the entry chunk", () =>
 	expect(scriptSrcMatches).toHaveLength(2);
 	const [vendorUrl, entryUrl] = scriptSrcMatches;
 	expect(vendorUrl).toContain("vendor");
-	expect(entryUrl).toMatch(/page\.js/);
+	expect(entryUrl).toMatch(/entry\.js/);
 	// vendor.js is a separate file and the entry chunk references it via require.
 	expect(readFile(vendorUrl)).toContain('"vendor-module"');
 	expect(readFile(entryUrl)).toContain("entry:");

--- a/test/configCases/html/extract/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/extract/__snapshots__/ConfigCacheTest.snap
@@ -6,7 +6,7 @@ exports[`ConfigCacheTestCases html extract exported tests should emit page.html 
 <head>
 <title>Extracted HTML</title>
 <link rel=\\"icon\\" href=\\"31d6cfe0d16ae931b73c.png\\">
-<script src=\\"page.js\\"></script>
+<script src=\\"entry.js\\"></script>
 </head>
 <body>
 <h1>Hello</h1>

--- a/test/configCases/html/extract/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/extract/__snapshots__/ConfigTest.snap
@@ -6,7 +6,7 @@ exports[`ConfigTestCases html extract exported tests should emit page.html with 
 <head>
 <title>Extracted HTML</title>
 <link rel=\\"icon\\" href=\\"31d6cfe0d16ae931b73c.png\\">
-<script src=\\"page.js\\"></script>
+<script src=\\"entry.js\\"></script>
 </head>
 <body>
 <h1>Hello</h1>

--- a/test/configCases/html/extract/index.js
+++ b/test/configCases/html/extract/index.js
@@ -18,7 +18,7 @@ it("should emit page.html with rewritten URLs alongside the JS bundle", () => {
 	expect(extracted).not.toContain('href="./icon.png"');
 	expect(extracted).not.toContain('src="./image.png"');
 	// `<script src>` was rewritten to the chunk URL.
-	expect(extracted).toMatch(/<script src="page\.js">/);
+	expect(extracted).toMatch(/<script src="entry\.js">/);
 	// Asset URLs were rewritten to hashed filenames.
 	expect(extracted).toMatch(/<link rel="icon" href="[a-f0-9]+\.png">/);
 	expect(extracted).toMatch(/<img src="[a-f0-9]+\.png" alt="image">/);

--- a/test/configCases/html/extracted-entry-filenames-function/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/extracted-entry-filenames-function/__snapshots__/ConfigCacheTest.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigCacheTestCases html extracted-entry-filenames-function exported tests should name a page's script and link entries after their urls 1`] = `
+"<!DOCTYPE html>
+<html>
+<head>
+<title>Extracted entry filenames (function template)</title>
+<link rel=\\"stylesheet\\" href=\\"a.css\\">
+<script type=\\"module\\" src=\\"a.mjs\\"></script>
+</head>
+<body></body>
+</html>
+"
+`;

--- a/test/configCases/html/extracted-entry-filenames-function/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/extracted-entry-filenames-function/__snapshots__/ConfigCacheTest.snap
@@ -5,8 +5,8 @@ exports[`ConfigCacheTestCases html extracted-entry-filenames-function exported t
 <html>
 <head>
 <title>Extracted entry filenames (function template)</title>
-<link rel=\\"stylesheet\\" href=\\"a.css\\">
-<script type=\\"module\\" src=\\"a.mjs\\"></script>
+<link rel=\\"stylesheet\\" href=\\"styles/a.css\\">
+<script type=\\"module\\" src=\\"assets/a.mjs\\"></script>
 </head>
 <body></body>
 </html>

--- a/test/configCases/html/extracted-entry-filenames-function/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/extracted-entry-filenames-function/__snapshots__/ConfigTest.snap
@@ -5,8 +5,8 @@ exports[`ConfigTestCases html extracted-entry-filenames-function exported tests 
 <html>
 <head>
 <title>Extracted entry filenames (function template)</title>
-<link rel=\\"stylesheet\\" href=\\"a.css\\">
-<script type=\\"module\\" src=\\"a.mjs\\"></script>
+<link rel=\\"stylesheet\\" href=\\"styles/a.css\\">
+<script type=\\"module\\" src=\\"assets/a.mjs\\"></script>
 </head>
 <body></body>
 </html>

--- a/test/configCases/html/extracted-entry-filenames-function/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/extracted-entry-filenames-function/__snapshots__/ConfigTest.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigTestCases html extracted-entry-filenames-function exported tests should name a page's script and link entries after their urls 1`] = `
+"<!DOCTYPE html>
+<html>
+<head>
+<title>Extracted entry filenames (function template)</title>
+<link rel=\\"stylesheet\\" href=\\"a.css\\">
+<script type=\\"module\\" src=\\"a.mjs\\"></script>
+</head>
+<body></body>
+</html>
+"
+`;

--- a/test/configCases/html/extracted-entry-filenames-function/a.css
+++ b/test/configCases/html/extracted-entry-filenames-function/a.css
@@ -1,0 +1,1 @@
+.a { color: red; }

--- a/test/configCases/html/extracted-entry-filenames-function/a.js
+++ b/test/configCases/html/extracted-entry-filenames-function/a.js
@@ -1,0 +1,1 @@
+globalThis.__a = "a";

--- a/test/configCases/html/extracted-entry-filenames-function/index.js
+++ b/test/configCases/html/extracted-entry-filenames-function/index.js
@@ -1,0 +1,20 @@
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+it("should name a page's script and link entries after their urls", () => {
+	expect(
+		fs.readFileSync(path.resolve(here, "page.html"), "utf-8")
+	).toMatchSnapshot();
+});
+
+it("should fall back to a plain [name] the url can fill", () => {
+	// `.mjs` because `output.module` is on; `a.css` rather than the `[id].css`
+	// the function left behind, which would name the synthetic id.
+	const files = fs.readdirSync(here);
+	expect(files).toContain("a.mjs");
+	expect(files).toContain("a.css");
+	expect(files).not.toContain("main.css");
+});

--- a/test/configCases/html/extracted-entry-filenames-function/index.js
+++ b/test/configCases/html/extracted-entry-filenames-function/index.js
@@ -2,19 +2,20 @@ import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
 
-const here = path.dirname(fileURLToPath(import.meta.url));
+// The filename function puts this bundle in `assets/`, so the output root is
+// its parent.
+const out = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
 it("should name a page's script and link entries after their urls", () => {
 	expect(
-		fs.readFileSync(path.resolve(here, "page.html"), "utf-8")
+		fs.readFileSync(path.resolve(out, "page.html"), "utf-8")
 	).toMatchSnapshot();
 });
 
-it("should fall back to a plain [name] the url can fill", () => {
-	// `.mjs` because `output.module` is on; `a.css` rather than the `[id].css`
-	// the function left behind, which would name the synthetic id.
-	const files = fs.readdirSync(here);
-	expect(files).toContain("a.mjs");
-	expect(files).toContain("a.css");
-	expect(files).not.toContain("main.css");
+it("should keep the directory the filename function returned", () => {
+	// The function ran for the extracted entries too, so only the stem it
+	// built from the synthetic chunk name was replaced by the tag's url.
+	expect(fs.readdirSync(path.resolve(out, "assets"))).toContain("a.mjs");
+	expect(fs.readdirSync(path.resolve(out, "styles"))).toContain("a.css");
+	expect(fs.readdirSync(out)).not.toContain("a.mjs");
 });

--- a/test/configCases/html/extracted-entry-filenames-function/page.html
+++ b/test/configCases/html/extracted-entry-filenames-function/page.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Extracted entry filenames (function template)</title>
+<link rel="stylesheet" href="./a.css">
+<script src="./a.js"></script>
+</head>
+<body></body>
+</html>

--- a/test/configCases/html/extracted-entry-filenames-function/test.config.js
+++ b/test/configCases/html/extracted-entry-filenames-function/test.config.js
@@ -1,0 +1,8 @@
+"use strict";
+
+// The filename function puts the test bundle at `main.mjs`.
+module.exports = {
+	findBundle() {
+		return ["./main.mjs"];
+	}
+};

--- a/test/configCases/html/extracted-entry-filenames-function/test.config.js
+++ b/test/configCases/html/extracted-entry-filenames-function/test.config.js
@@ -1,8 +1,8 @@
 "use strict";
 
-// The filename function puts the test bundle at `main.mjs`.
+// The filename function puts the test bundle under `assets/`.
 module.exports = {
 	findBundle() {
-		return ["./main.mjs"];
+		return ["./assets/main.mjs"];
 	}
 };

--- a/test/configCases/html/extracted-entry-filenames-function/test.filter.js
+++ b/test/configCases/html/extracted-entry-filenames-function/test.filter.js
@@ -1,0 +1,8 @@
+"use strict";
+
+// The test reads the emitted files through `import.meta.url`, which needs
+// Node 12+ to parse when the harness executes the bundle.
+module.exports = function filter() {
+	const major = Number(process.versions.node.split(".")[0]);
+	return major >= 12;
+};

--- a/test/configCases/html/extracted-entry-filenames-function/webpack.config.js
+++ b/test/configCases/html/extracted-entry-filenames-function/webpack.config.js
@@ -1,7 +1,7 @@
 "use strict";
 
-// A function `output.filename` cannot be read for a `[name]`, and the
-// `[id].css` it leaves behind would name synthetic ids — both fall back.
+// A function `output.filename` is called for an extracted entry too, so the
+// directory it returns is kept and only the file's stem is renamed.
 
 /** @type {import("../../../../").Configuration} */
 module.exports = {
@@ -25,7 +25,8 @@ module.exports = {
 		page: "./page.html"
 	},
 	output: {
-		filename: (pathData) => `${pathData.chunk.name}.mjs`,
+		filename: (pathData) => `assets/${pathData.chunk.name}.mjs`,
+		cssFilename: (pathData) => `styles/${pathData.chunk.name}.css`,
 		module: true
 	},
 	optimization: {

--- a/test/configCases/html/extracted-entry-filenames-function/webpack.config.js
+++ b/test/configCases/html/extracted-entry-filenames-function/webpack.config.js
@@ -1,0 +1,39 @@
+"use strict";
+
+// A function `output.filename` cannot be read for a `[name]`, and the
+// `[id].css` it leaves behind would name synthetic ids — both fall back.
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: ["web", "es2022"],
+	node: {
+		__dirname: false,
+		__filename: false
+	},
+	externalsPresets: {
+		node: true
+	},
+	module: {
+		parser: {
+			javascript: {
+				importMeta: false
+			}
+		}
+	},
+	entry: {
+		main: "./index.js",
+		page: "./page.html"
+	},
+	output: {
+		filename: (pathData) => `${pathData.chunk.name}.mjs`,
+		module: true
+	},
+	optimization: {
+		chunkIds: "named"
+	},
+	experiments: {
+		html: true,
+		css: true,
+		outputModule: true
+	}
+};

--- a/test/configCases/html/extracted-entry-filenames/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/extracted-entry-filenames/__snapshots__/ConfigCacheTest.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigCacheTestCases html extracted-entry-filenames exported tests should name a page's script and link entries after their urls 1`] = `
+"<!DOCTYPE html>
+<html>
+<head>
+<title>Extracted entry filenames</title>
+<link rel=\\"stylesheet\\" href=\\"a.css\\">
+<link rel=\\"stylesheet\\" href=\\"b.css\\">
+<script src=\\"js/a.js\\"></script>
+<script src=\\"js/b.js\\"></script>
+</head>
+<body></body>
+</html>
+"
+`;

--- a/test/configCases/html/extracted-entry-filenames/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/extracted-entry-filenames/__snapshots__/ConfigTest.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ConfigTestCases html extracted-entry-filenames exported tests should name a page's script and link entries after their urls 1`] = `
+"<!DOCTYPE html>
+<html>
+<head>
+<title>Extracted entry filenames</title>
+<link rel=\\"stylesheet\\" href=\\"a.css\\">
+<link rel=\\"stylesheet\\" href=\\"b.css\\">
+<script src=\\"js/a.js\\"></script>
+<script src=\\"js/b.js\\"></script>
+</head>
+<body></body>
+</html>
+"
+`;

--- a/test/configCases/html/extracted-entry-filenames/a.css
+++ b/test/configCases/html/extracted-entry-filenames/a.css
@@ -1,0 +1,1 @@
+.a { color: red; }

--- a/test/configCases/html/extracted-entry-filenames/a.js
+++ b/test/configCases/html/extracted-entry-filenames/a.js
@@ -1,0 +1,1 @@
+globalThis.__a = "a";

--- a/test/configCases/html/extracted-entry-filenames/b.css
+++ b/test/configCases/html/extracted-entry-filenames/b.css
@@ -1,0 +1,1 @@
+.b { color: blue; }

--- a/test/configCases/html/extracted-entry-filenames/b.js
+++ b/test/configCases/html/extracted-entry-filenames/b.js
@@ -1,0 +1,1 @@
+globalThis.__b = "b";

--- a/test/configCases/html/extracted-entry-filenames/index.js
+++ b/test/configCases/html/extracted-entry-filenames/index.js
@@ -1,0 +1,24 @@
+const fs = require("fs");
+const path = require("path");
+
+// This bundle is emitted into `js/`, so the output root is one level up.
+const outputRoot = path.resolve(__dirname, "..");
+
+it("should name a page's script and link entries after their urls", () => {
+	expect(
+		fs.readFileSync(path.resolve(outputRoot, "page.html"), "utf-8")
+	).toMatchSnapshot();
+});
+
+it("should keep the directory each filename template asked for", () => {
+	// `js/bundle.js` lends its `js/` and `.js`, `styles.css` its root and
+	// `.css` — neither template is consulted for `output.chunkFilename`.
+	expect(fs.readdirSync(path.resolve(outputRoot, "js")).sort()).toEqual([
+		"a.js",
+		"b.js",
+		"bundle.js"
+	]);
+	const files = fs.readdirSync(outputRoot);
+	expect(files).toContain("a.css");
+	expect(files).toContain("b.css");
+});

--- a/test/configCases/html/extracted-entry-filenames/page.html
+++ b/test/configCases/html/extracted-entry-filenames/page.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Extracted entry filenames</title>
+<link rel="stylesheet" href="./a.css">
+<link rel="stylesheet" href="./b.css">
+<script src="./a.js"></script>
+<script src="./b.js"></script>
+</head>
+<body></body>
+</html>

--- a/test/configCases/html/extracted-entry-filenames/test.config.js
+++ b/test/configCases/html/extracted-entry-filenames/test.config.js
@@ -1,0 +1,8 @@
+"use strict";
+
+// `output.filename` puts the test bundle at `js/bundle.js`, not `bundle0.js`.
+module.exports = {
+	findBundle() {
+		return ["./js/bundle.js"];
+	}
+};

--- a/test/configCases/html/extracted-entry-filenames/webpack.config.js
+++ b/test/configCases/html/extracted-entry-filenames/webpack.config.js
@@ -1,0 +1,31 @@
+"use strict";
+
+// `output.filename` and `output.cssFilename` name no chunk here, so the page's
+// `<script>`/`<link>` entries take a `[name]`, filled in from each tag's url.
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	node: {
+		__dirname: false,
+		__filename: false
+	},
+	externalsPresets: {
+		node: true
+	},
+	entry: {
+		main: "./index.js",
+		page: "./page.html"
+	},
+	output: {
+		filename: "js/bundle.js",
+		cssFilename: "styles.css"
+	},
+	optimization: {
+		chunkIds: "named"
+	},
+	experiments: {
+		html: true,
+		css: true
+	}
+};

--- a/test/configCases/html/extracted-entry-name-collision/a/app.js
+++ b/test/configCases/html/extracted-entry-name-collision/a/app.js
@@ -1,0 +1,1 @@
+globalThis.__first = "first-page-script";

--- a/test/configCases/html/extracted-entry-name-collision/a/first.html
+++ b/test/configCases/html/extracted-entry-name-collision/a/first.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<html><head><script src="./app.js"></script></head><body>First</body></html>

--- a/test/configCases/html/extracted-entry-name-collision/b/app.js
+++ b/test/configCases/html/extracted-entry-name-collision/b/app.js
@@ -1,0 +1,1 @@
+globalThis.__second = "second-page-script";

--- a/test/configCases/html/extracted-entry-name-collision/b/second.html
+++ b/test/configCases/html/extracted-entry-name-collision/b/second.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<html><head><script src="./app.js"></script></head><body>Second</body></html>

--- a/test/configCases/html/extracted-entry-name-collision/index.html
+++ b/test/configCases/html/extracted-entry-name-collision/index.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<head><title>Hub</title></head>
+<body>
+<a href="./a/first.html">First</a>
+<a href="./b/second.html">Second</a>
+</body>
+</html>

--- a/test/configCases/html/extracted-entry-name-collision/index.html
+++ b/test/configCases/html/extracted-entry-name-collision/index.html
@@ -2,7 +2,7 @@
 <html>
 <head><title>Hub</title></head>
 <body>
-<a href="./a/first.html">First</a>
 <a href="./b/second.html">Second</a>
+<a href="./a/first.html">First</a>
 </body>
 </html>

--- a/test/configCases/html/extracted-entry-name-collision/test.config.js
+++ b/test/configCases/html/extracted-entry-name-collision/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["./test.js"];
+	}
+};

--- a/test/configCases/html/extracted-entry-name-collision/test.js
+++ b/test/configCases/html/extracted-entry-name-collision/test.js
@@ -8,10 +8,10 @@ it("should number a second page's script past a basename the first one took", ()
 	expect(files).toContain("app.js");
 	expect(files).toContain("app1.js");
 
-	// Both pages load `./app.js`, and the pages are named in a sorted order
-	// rather than in whichever order their builds finished.
-	expect(read("first.html")).toMatch(/<script src="app\.js">/);
-	expect(read("second.html")).toMatch(/<script src="app1\.js">/);
-	expect(read("app.js")).toContain("first-page-script");
-	expect(read("app1.js")).toContain("second-page-script");
+	// Both pages load `./app.js`, and the links are in the reverse of their
+	// lexical order, so only document order gives `second.html` the plain name.
+	expect(read("second.html")).toMatch(/<script src="app\.js">/);
+	expect(read("first.html")).toMatch(/<script src="app1\.js">/);
+	expect(read("app.js")).toContain("second-page-script");
+	expect(read("app1.js")).toContain("first-page-script");
 });

--- a/test/configCases/html/extracted-entry-name-collision/test.js
+++ b/test/configCases/html/extracted-entry-name-collision/test.js
@@ -1,0 +1,17 @@
+const fs = require("fs");
+const path = require("path");
+
+const read = (name) => fs.readFileSync(path.resolve(__dirname, name), "utf-8");
+
+it("should number a second page's script past a basename the first one took", () => {
+	const files = fs.readdirSync(__dirname);
+	expect(files).toContain("app.js");
+	expect(files).toContain("app1.js");
+
+	// Both pages load `./app.js`, and the pages are named in a sorted order
+	// rather than in whichever order their builds finished.
+	expect(read("first.html")).toMatch(/<script src="app\.js">/);
+	expect(read("second.html")).toMatch(/<script src="app1\.js">/);
+	expect(read("app.js")).toContain("first-page-script");
+	expect(read("app1.js")).toContain("second-page-script");
+});

--- a/test/configCases/html/extracted-entry-name-collision/webpack.config.js
+++ b/test/configCases/html/extracted-entry-name-collision/webpack.config.js
@@ -1,7 +1,7 @@
 "use strict";
 
-// Two linked pages whose scripts share a basename: the first page in sorted
-// order keeps `app.js` and the other is numbered past it, on every build.
+// Two linked pages whose scripts share a basename, linked against their lexical
+// order: the one linked first keeps `app.js`, the other is numbered past it.
 
 const fs = require("fs");
 const path = require("path");

--- a/test/configCases/html/extracted-entry-name-collision/webpack.config.js
+++ b/test/configCases/html/extracted-entry-name-collision/webpack.config.js
@@ -1,0 +1,51 @@
+"use strict";
+
+// Two linked pages whose scripts share a basename: the first page in sorted
+// order keeps `app.js` and the other is numbered past it, on every build.
+
+const fs = require("fs");
+const path = require("path");
+const webpack = require("../../../../");
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	entry: { main: "./index.html" },
+	output: {
+		filename: "[name].js",
+		chunkFilename: "[name].chunk.js"
+	},
+	module: {
+		parser: {
+			html: {
+				sources: ["...", { tag: "a", attribute: "href", type: "html" }]
+			}
+		}
+	},
+	optimization: { chunkIds: "named" },
+	experiments: { html: true },
+	plugins: [
+		{
+			apply(compiler) {
+				// No page emits JavaScript of its own, so the assertions ride in on
+				// an asset of their own.
+				compiler.hooks.compilation.tap("Test", (compilation) => {
+					compilation.hooks.processAssets.tap(
+						{
+							name: "copy-test",
+							stage:
+								compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
+						},
+						() => {
+							const data = fs.readFileSync(path.resolve(__dirname, "test.js"));
+							compilation.emitAsset(
+								"test.js",
+								new webpack.sources.RawSource(data)
+							);
+						}
+					);
+				});
+			}
+		}
+	]
+};

--- a/test/configCases/html/html-entry-include-dependencies/test.js
+++ b/test/configCases/html/html-entry-include-dependencies/test.js
@@ -6,16 +6,16 @@ it("should keep the JS asset of an entry that includes more than its page", () =
 
 	expect(files).toContain("page.html");
 	expect(files).toContain("main.js");
-	expect(files).toContain("page.js");
+	expect(files).toContain("script.js");
 
 	// The entry is not the page alone, so it keeps the entry filename and the
 	// extracted script is named after the page's file.
 	const main = fs.readFileSync(path.resolve(__dirname, "main.js"), "utf-8");
 	expect(main).toContain("included");
 
-	const script = fs.readFileSync(path.resolve(__dirname, "page.js"), "utf-8");
+	const script = fs.readFileSync(path.resolve(__dirname, "script.js"), "utf-8");
 	expect(script).toContain("html-entry-script");
 
 	const html = fs.readFileSync(path.resolve(__dirname, "page.html"), "utf-8");
-	expect(html).toMatch(/<script src="page\.js">/);
+	expect(html).toMatch(/<script src="script\.js">/);
 });

--- a/test/configCases/html/html-entry-library-js-asset/test.js
+++ b/test/configCases/html/html-entry-library-js-asset/test.js
@@ -8,13 +8,13 @@ it("should keep the JS asset of an HTML entry exposed as a library", () => {
 	expect(files).toContain("page.js");
 
 	const html = fs.readFileSync(path.resolve(__dirname, "page.html"), "utf-8");
-	expect(html).toMatch(/<script src="__html_[a-f0-9]+_0\.chunk\.js">/);
+	// `page.js` is the library asset; the script takes its own url's name.
+	expect(html).toMatch(/<script src="script\.js">/);
+	expect(files).toContain("script.js");
 
 	// The hint keeps the page's own library asset and adds the extracted one.
 	expect(html).toMatch(/<link rel="preload" as="script" href="page\.js">/);
-	expect(html).toMatch(
-		/<link rel="preload" as="script" href="__html_[a-f0-9]+_0\.chunk\.js">/
-	);
+	expect(html).toMatch(/<link rel="preload" as="script" href="script\.js">/);
 
 	// The library hands back the page markup.
 	expect(require("./page.js")).toContain("<title>HTML entry exposed as a library</title>");

--- a/test/configCases/html/html-entry-no-js-asset/test.js
+++ b/test/configCases/html/html-entry-no-js-asset/test.js
@@ -5,14 +5,14 @@ it("should not emit a JS copy of the page for an HTML entry", () => {
 	const files = fs.readdirSync(__dirname);
 
 	expect(files).toContain("page.html");
-	expect(files).toContain("page.js");
+	expect(files).toContain("script.js");
 
-	// `page.js` is the script the parser split out of the page — it takes the
+	// `script.js` is the script the parser split out of the page — it takes the
 	// entry's filename, which no copy of the markup occupies any more.
-	const js = fs.readFileSync(path.resolve(__dirname, "page.js"), "utf-8");
+	const js = fs.readFileSync(path.resolve(__dirname, "script.js"), "utf-8");
 	expect(js).toContain("html-entry-script");
 	expect(js).not.toContain("<!DOCTYPE html>");
 
 	const html = fs.readFileSync(path.resolve(__dirname, "page.html"), "utf-8");
-	expect(html).toMatch(/<script src="page\.js">/);
+	expect(html).toMatch(/<script src="script\.js">/);
 });

--- a/test/configCases/html/html-entry-point-css/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/html-entry-point-css/__snapshots__/ConfigCacheTest.snap
@@ -5,7 +5,7 @@ exports[`ConfigCacheTestCases html html-entry-point-css exported tests should em
 <html>
 <head>
 <title>HTML entry point with CSS</title>
-<link rel=\\"stylesheet\\" href=\\"page.css\\">
+<link rel=\\"stylesheet\\" href=\\"style.css\\">
 </head>
 <body>
 <h1>Hello</h1>

--- a/test/configCases/html/html-entry-point-css/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/html-entry-point-css/__snapshots__/ConfigTest.snap
@@ -5,7 +5,7 @@ exports[`ConfigTestCases html html-entry-point-css exported tests should emit pa
 <html>
 <head>
 <title>HTML entry point with CSS</title>
-<link rel=\\"stylesheet\\" href=\\"page.css\\">
+<link rel=\\"stylesheet\\" href=\\"style.css\\">
 </head>
 <body>
 <h1>Hello</h1>

--- a/test/configCases/html/html-entry-point/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/html-entry-point/__snapshots__/ConfigCacheTest.snap
@@ -5,7 +5,7 @@ exports[`ConfigCacheTestCases html html-entry-point exported tests should emit p
 <html>
 <head>
 <title>HTML entry point</title>
-<script src=\\"page.js\\"></script>
+<script src=\\"script.js\\"></script>
 </head>
 <body>
 <img src=\\"31d6cfe0d16ae931b73c.png\\" alt=\\"image\\">

--- a/test/configCases/html/html-entry-point/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/html-entry-point/__snapshots__/ConfigTest.snap
@@ -5,7 +5,7 @@ exports[`ConfigTestCases html html-entry-point exported tests should emit page.h
 <html>
 <head>
 <title>HTML entry point</title>
-<script src=\\"page.js\\"></script>
+<script src=\\"script.js\\"></script>
 </head>
 <body>
 <img src=\\"31d6cfe0d16ae931b73c.png\\" alt=\\"image\\">

--- a/test/configCases/html/html-entry-point/test.js
+++ b/test/configCases/html/html-entry-point/test.js
@@ -9,6 +9,6 @@ it("should emit page.html for an HTML entry without explicit extract: true", () 
 	expect(extracted).toMatchSnapshot();
 	expect(extracted).not.toContain('src="./script.js"');
 	expect(extracted).not.toContain('src="./image.png"');
-	expect(extracted).toMatch(/<script src="page\.js">/);
+	expect(extracted).toMatch(/<script src="script\.js">/);
 	expect(extracted).toMatch(/<img src="[a-f0-9]+\.png" alt="image">/);
 });

--- a/test/configCases/html/html-entry-with-js/index.js
+++ b/test/configCases/html/html-entry-with-js/index.js
@@ -7,6 +7,7 @@ it("should keep the extracted script's name when the entry also bundles JS", () 
 	expect(files).toContain("page.js");
 
 	const html = fs.readFileSync(path.resolve(__dirname, "page.html"), "utf-8");
-	// `page.js` is this bundle, so the page's script cannot take that name.
-	expect(html).toMatch(/<script src="__html_[a-f0-9]+_0\.chunk\.js">/);
+	// `page.js` is this bundle; the page's script takes its own url's name.
+	expect(html).toMatch(/<script src="script\.js">/);
+	expect(files).toContain("script.js");
 });

--- a/test/configCases/html/html-imported-page-name/index.js
+++ b/test/configCases/html/html-imported-page-name/index.js
@@ -3,11 +3,11 @@ const path = require("path");
 
 import page from "./page.html";
 
-it("should name an imported page's script after that page", () => {
-	// The page has no entry of its own, so its script is named after its file.
+it("should name an imported page's script after its src", () => {
+	// The page has no entry of its own; its script is named after its url.
 	expect(page).toContain("<title>Widget</title>");
-	expect(fs.readdirSync(__dirname)).toContain("page.js");
+	expect(fs.readdirSync(__dirname)).toContain("widget.js");
 
-	const js = fs.readFileSync(path.resolve(__dirname, "page.js"), "utf-8");
+	const js = fs.readFileSync(path.resolve(__dirname, "widget.js"), "utf-8");
 	expect(js).toContain("widget-script");
 });

--- a/test/configCases/html/html-linked-page-graph/a.html
+++ b/test/configCases/html/html-linked-page-graph/a.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html>
+<head><title>A</title><script src="./first.js"></script></head>
+<body><a href="./shared.html">Shared</a></body>
+</html>

--- a/test/configCases/html/html-linked-page-graph/b.html
+++ b/test/configCases/html/html-linked-page-graph/b.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html>
+<head><title>B</title><script src="./second.js"></script></head>
+<body><a href="./shared.html">Shared</a></body>
+</html>

--- a/test/configCases/html/html-linked-page-graph/deep.js
+++ b/test/configCases/html/html-linked-page-graph/deep.js
@@ -1,0 +1,1 @@
+module.exports = "deep";

--- a/test/configCases/html/html-linked-page-graph/first.js
+++ b/test/configCases/html/html-linked-page-graph/first.js
@@ -1,0 +1,1 @@
+module.exports = "first";

--- a/test/configCases/html/html-linked-page-graph/home.js
+++ b/test/configCases/html/html-linked-page-graph/home.js
@@ -1,0 +1,1 @@
+module.exports = "home";

--- a/test/configCases/html/html-linked-page-graph/index.html
+++ b/test/configCases/html/html-linked-page-graph/index.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html>
+<head><title>Home</title><script src="./home.js"></script></head>
+<body><a href="./a.html">A</a><a href="./b.html">B</a></body>
+</html>

--- a/test/configCases/html/html-linked-page-graph/second.js
+++ b/test/configCases/html/html-linked-page-graph/second.js
@@ -1,0 +1,1 @@
+module.exports = "second";

--- a/test/configCases/html/html-linked-page-graph/shared.html
+++ b/test/configCases/html/html-linked-page-graph/shared.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html>
+<head><title>Shared</title><script src="./deep.js"></script></head>
+<body><a href="./index.html">Home</a></body>
+</html>

--- a/test/configCases/html/html-linked-page-graph/test.config.js
+++ b/test/configCases/html/html-linked-page-graph/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["./test.js"];
+	}
+};

--- a/test/configCases/html/html-linked-page-graph/test.js
+++ b/test/configCases/html/html-linked-page-graph/test.js
@@ -5,9 +5,13 @@ const read = (name) => fs.readFileSync(path.resolve(__dirname, name), "utf-8");
 
 it("should name a page reached by several links once", () => {
 	const files = fs.readdirSync(__dirname);
+	// A url claimed twice would take a numbered name, so the suffixed
+	// spellings have to be absent rather than merely outnumbered.
+	const matching = (pattern) =>
+		files.filter((file) => pattern.test(file)).sort();
 
-	expect(files.filter((file) => file === "shared.html")).toHaveLength(1);
-	expect(files.filter((file) => file === "deep.js")).toHaveLength(1);
+	expect(matching(/^shared\d*\.html$/)).toEqual(["shared.html"]);
+	expect(matching(/^deep\d*\.js$/)).toEqual(["deep.js"]);
 	expect(read("shared.html")).toMatch(/<script src="deep\.js">/);
 	expect(read("a.html")).toMatch(/<a href="shared\.html">/);
 	expect(read("b.html")).toMatch(/<a href="shared\.html">/);

--- a/test/configCases/html/html-linked-page-graph/test.js
+++ b/test/configCases/html/html-linked-page-graph/test.js
@@ -1,0 +1,19 @@
+const fs = require("fs");
+const path = require("path");
+
+const read = (name) => fs.readFileSync(path.resolve(__dirname, name), "utf-8");
+
+it("should name a page reached by several links once", () => {
+	const files = fs.readdirSync(__dirname);
+
+	expect(files.filter((file) => file === "shared.html")).toHaveLength(1);
+	expect(files.filter((file) => file === "deep.js")).toHaveLength(1);
+	expect(read("shared.html")).toMatch(/<script src="deep\.js">/);
+	expect(read("a.html")).toMatch(/<a href="shared\.html">/);
+	expect(read("b.html")).toMatch(/<a href="shared\.html">/);
+	// The link back to the entry page closes a cycle, and names nothing twice.
+	expect(read("shared.html")).toMatch(/<a href="index\.html">/);
+	expect(read("index.html")).toMatch(/<script src="home\.js">/);
+	expect(files).toContain("first.js");
+	expect(files).toContain("second.js");
+});

--- a/test/configCases/html/html-linked-page-graph/webpack.config.js
+++ b/test/configCases/html/html-linked-page-graph/webpack.config.js
@@ -1,0 +1,51 @@
+"use strict";
+
+// Two pages link the same third page, which links back to the entry page:
+// every page is named once, however many links reach it.
+
+const fs = require("fs");
+const path = require("path");
+const webpack = require("../../../../");
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	entry: { main: "./index.html" },
+	output: {
+		filename: "[name].js",
+		chunkFilename: "[name].chunk.js"
+	},
+	module: {
+		parser: {
+			html: {
+				sources: ["...", { tag: "a", attribute: "href", type: "html" }]
+			}
+		}
+	},
+	optimization: { chunkIds: "named" },
+	experiments: { html: true },
+	plugins: [
+		{
+			apply(compiler) {
+				// No page emits JavaScript of its own, so the assertions ride in on
+				// an asset of their own.
+				compiler.hooks.compilation.tap("Test", (compilation) => {
+					compilation.hooks.processAssets.tap(
+						{
+							name: "copy-test",
+							stage:
+								compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
+						},
+						() => {
+							const data = fs.readFileSync(path.resolve(__dirname, "test.js"));
+							compilation.emitAsset(
+								"test.js",
+								new webpack.sources.RawSource(data)
+							);
+						}
+					);
+				});
+			}
+		}
+	]
+};

--- a/test/configCases/html/html-linked-page-name-taken/about.html
+++ b/test/configCases/html/html-linked-page-name-taken/about.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
 <html>
-<head><title>About</title><script src="./about-page.js"></script></head>
+<head><title>About</title><script src="./about.js"></script></head>
 <body></body>
 </html>

--- a/test/configCases/html/html-linked-page-name-taken/about.js
+++ b/test/configCases/html/html-linked-page-name-taken/about.js
@@ -1,0 +1,1 @@
+globalThis.__aboutScript = "about-script";

--- a/test/configCases/html/html-linked-page-name-taken/test.js
+++ b/test/configCases/html/html-linked-page-name-taken/test.js
@@ -1,14 +1,20 @@
 const fs = require("fs");
 const path = require("path");
 
-it("should leave a page's script alone when its name is taken", () => {
+it("should number a page's script past a name an entry already emits", () => {
 	const about = fs.readFileSync(path.resolve(__dirname, "about.html"), "utf-8");
+	const files = fs.readdirSync(__dirname);
 
-	// `about.js` is the JavaScript entry's bundle, so the page keeps the name
-	// the parser gave its script rather than colliding with it.
-	expect(about).toMatch(/<script src="__html_[a-f0-9]+_0\.chunk\.js">/);
-	expect(fs.readdirSync(__dirname)).toContain("about.js");
+	// `about.js` is the JavaScript entry's bundle, so the page's script of the
+	// same name is numbered past it rather than colliding with it.
+	expect(about).toMatch(/<script src="about1\.js">/);
+	expect(files).toContain("about.js");
+	expect(files).toContain("about1.js");
 
-	const js = fs.readFileSync(path.resolve(__dirname, "about.js"), "utf-8");
-	expect(js).toContain("about-page");
+	expect(
+		fs.readFileSync(path.resolve(__dirname, "about.js"), "utf-8")
+	).toContain("about-page");
+	expect(
+		fs.readFileSync(path.resolve(__dirname, "about1.js"), "utf-8")
+	).toContain("about-script");
 });

--- a/test/configCases/html/html-linked-page-name-taken/webpack.config.js
+++ b/test/configCases/html/html-linked-page-name-taken/webpack.config.js
@@ -1,7 +1,7 @@
 "use strict";
 
-// An entry already called `about` owns that name, so the linked `about.html`
-// page cannot take it and its script keeps the name the parser gave it.
+// An entry already called `about` emits `about.js`, so the linked page's
+// `<script src="./about.js">` cannot have that name and is numbered past it.
 
 const fs = require("fs");
 const path = require("path");

--- a/test/configCases/html/html-linked-page-name/test.js
+++ b/test/configCases/html/html-linked-page-name/test.js
@@ -3,12 +3,12 @@ const path = require("path");
 
 const read = (name) => fs.readFileSync(path.resolve(__dirname, name), "utf-8");
 
-it("should name a linked page's script after that page", () => {
+it("should name a linked page's script after its src", () => {
 	const files = fs.readdirSync(__dirname);
 
-	expect(files).toContain("about.js");
-	expect(read("about.html")).toMatch(/<script src="about\.js">/);
-	// The entry page still takes its entry's name.
-	expect(read("index.html")).toMatch(/<script src="main\.js">/);
-	expect(files).toContain("main.js");
+	expect(files).toContain("about-page.js");
+	expect(read("about.html")).toMatch(/<script src="about-page\.js">/);
+	// The page an entry points at is no different — its src names it too.
+	expect(read("index.html")).toMatch(/<script src="home\.js">/);
+	expect(files).toContain("home.js");
 });

--- a/test/configCases/html/html-linked-page-name/webpack.config.js
+++ b/test/configCases/html/html-linked-page-name/webpack.config.js
@@ -1,7 +1,7 @@
 "use strict";
 
-// A page linked from another page has no entry name of its own, so the
-// entries extracted from it are named after its file instead.
+// A page linked from another page: the entries extracted from it are named
+// after the urls its tags carry, like the entry page's own.
 
 const fs = require("fs");
 const path = require("path");

--- a/test/configCases/html/iframe-srcdoc-css/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/iframe-srcdoc-css/__snapshots__/ConfigCacheTest.snap
@@ -13,7 +13,7 @@ exports[`ConfigCacheTestCases html iframe-srcdoc-css exported tests should proce
 </style>\\"></iframe>
 <iframe srcdoc=\\"<style>body{background:url(handled-pixel.png)}
 </style>\\"></iframe>
-<iframe srcdoc=\\"<link rel=&quot;stylesheet&quot; href=&quot;576.bundle0.css&quot;>\\"></iframe>
+<iframe srcdoc=\\"<link rel=&quot;stylesheet&quot; href=&quot;linked.css&quot;>\\"></iframe>
 </body>
 </html>
 "

--- a/test/configCases/html/iframe-srcdoc-css/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/iframe-srcdoc-css/__snapshots__/ConfigTest.snap
@@ -13,7 +13,7 @@ exports[`ConfigTestCases html iframe-srcdoc-css exported tests should process CS
 </style>\\"></iframe>
 <iframe srcdoc=\\"<style>body{background:url(handled-pixel.png)}
 </style>\\"></iframe>
-<iframe srcdoc=\\"<link rel=&quot;stylesheet&quot; href=&quot;576.bundle0.css&quot;>\\"></iframe>
+<iframe srcdoc=\\"<link rel=&quot;stylesheet&quot; href=&quot;linked.css&quot;>\\"></iframe>
 </body>
 </html>
 "

--- a/test/configCases/html/iframe-srcdoc-inline-name/home.html
+++ b/test/configCases/html/iframe-srcdoc-inline-name/home.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<head><title>Home</title></head>
+<body>
+<iframe srcdoc="<script>var marker = 1;</script>"></iframe>
+</body>
+</html>

--- a/test/configCases/html/iframe-srcdoc-inline-name/index.js
+++ b/test/configCases/html/iframe-srcdoc-inline-name/index.js
@@ -1,0 +1,7 @@
+import home from "./home.html";
+
+it("should name a srcdoc's inline script after the page embedding it", () => {
+	// `home.html` carries the srcdoc, so the extracted body is `home.js` —
+	// not a name of webpack's own invention.
+	expect(home).toMatch(/src=&quot;home\.js&quot;/);
+});

--- a/test/configCases/html/iframe-srcdoc-inline-name/index.js
+++ b/test/configCases/html/iframe-srcdoc-inline-name/index.js
@@ -1,7 +1,8 @@
 import home from "./home.html";
 
-it("should name a srcdoc's inline script after the page embedding it", () => {
-	// `home.html` carries the srcdoc, so the extracted body is `home.js` —
-	// not a name of webpack's own invention.
-	expect(home).toMatch(/src=&quot;home\.js&quot;/);
+it("should name a srcdoc's inline script after its entry, not the page", () => {
+	// The srcdoc is a page webpack writes and its `<script>` carries no url,
+	// so neither lends a name — the entry's own is used.
+	expect(home).toMatch(/src=&quot;__html_[0-9a-f]+_\d+\.js&quot;/);
+	expect(home).not.toMatch(/src=&quot;home\d*\.js&quot;/);
 });

--- a/test/configCases/html/iframe-srcdoc-inline-name/webpack.config.js
+++ b/test/configCases/html/iframe-srcdoc-inline-name/webpack.config.js
@@ -1,0 +1,19 @@
+"use strict";
+
+// An `<iframe srcdoc>` is a page webpack writes, so it has no file of its own.
+// Its inline `<script>` has no url either, and takes the embedding page's name.
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	devtool: false,
+	target: "web",
+	output: {
+		pathinfo: false
+	},
+	optimization: {
+		chunkIds: "named"
+	},
+	experiments: {
+		html: true
+	}
+};

--- a/test/configCases/html/iframe-srcdoc-inline-name/webpack.config.js
+++ b/test/configCases/html/iframe-srcdoc-inline-name/webpack.config.js
@@ -1,7 +1,7 @@
 "use strict";
 
-// An `<iframe srcdoc>` is a page webpack writes, so it has no file of its own.
-// Its inline `<script>` has no url either, and takes the embedding page's name.
+// Neither an `<iframe srcdoc>` page nor an inline `<script>` carries a url, so
+// the extracted entry keeps the name webpack gave it.
 
 /** @type {import("../../../../").Configuration} */
 module.exports = {

--- a/test/configCases/html/iframe-srcdoc-script/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/iframe-srcdoc-script/__snapshots__/ConfigCacheTest.snap
@@ -5,8 +5,8 @@ exports[`ConfigCacheTestCases html iframe-srcdoc-script exported tests should bu
 <html>
 <head><title>srcdoc script</title></head>
 <body>
-<iframe srcdoc=\\"<script src=&quot;__html_60417bb2_0.bundle0.js&quot;></script>\\"></iframe>
-<iframe srcdoc=\\"<script src=&quot;__html_cabc5adb_0.bundle0.js&quot;></script>\\"></iframe>
+<iframe srcdoc=\\"<script src=&quot;app.js&quot;></script>\\"></iframe>
+<iframe srcdoc=\\"<script src=&quot;page.js&quot;></script>\\"></iframe>
 </body>
 </html>
 "

--- a/test/configCases/html/iframe-srcdoc-script/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/iframe-srcdoc-script/__snapshots__/ConfigCacheTest.snap
@@ -6,7 +6,7 @@ exports[`ConfigCacheTestCases html iframe-srcdoc-script exported tests should bu
 <head><title>srcdoc script</title></head>
 <body>
 <iframe srcdoc=\\"<script src=&quot;app.js&quot;></script>\\"></iframe>
-<iframe srcdoc=\\"<script src=&quot;page.js&quot;></script>\\"></iframe>
+<iframe srcdoc=\\"<script src=&quot;__html_cabc5adb_0.js&quot;></script>\\"></iframe>
 </body>
 </html>
 "

--- a/test/configCases/html/iframe-srcdoc-script/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/iframe-srcdoc-script/__snapshots__/ConfigTest.snap
@@ -6,7 +6,7 @@ exports[`ConfigTestCases html iframe-srcdoc-script exported tests should bundle 
 <head><title>srcdoc script</title></head>
 <body>
 <iframe srcdoc=\\"<script src=&quot;app.js&quot;></script>\\"></iframe>
-<iframe srcdoc=\\"<script src=&quot;page.js&quot;></script>\\"></iframe>
+<iframe srcdoc=\\"<script src=&quot;__html_cabc5adb_0.js&quot;></script>\\"></iframe>
 </body>
 </html>
 "

--- a/test/configCases/html/iframe-srcdoc-script/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/iframe-srcdoc-script/__snapshots__/ConfigTest.snap
@@ -5,8 +5,8 @@ exports[`ConfigTestCases html iframe-srcdoc-script exported tests should bundle 
 <html>
 <head><title>srcdoc script</title></head>
 <body>
-<iframe srcdoc=\\"<script src=&quot;__html_60417bb2_0.bundle0.js&quot;></script>\\"></iframe>
-<iframe srcdoc=\\"<script src=&quot;__html_cabc5adb_0.bundle0.js&quot;></script>\\"></iframe>
+<iframe srcdoc=\\"<script src=&quot;app.js&quot;></script>\\"></iframe>
+<iframe srcdoc=\\"<script src=&quot;page.js&quot;></script>\\"></iframe>
 </body>
 </html>
 "

--- a/test/configCases/html/iframe-srcdoc-script/index.js
+++ b/test/configCases/html/iframe-srcdoc-script/index.js
@@ -22,8 +22,8 @@ it("should bundle <script> inside <iframe srcdoc> as an entry chunk", () => {
 	).toBeGreaterThanOrEqual(2);
 
 	// The bundled scripts become their own emitted JS chunks: one named after
-	// its `src`, and the inline body after the page that carries it.
+	// its `src`, and the inline body after its entry, having no url at all.
 	const names = __STATS__.assets.map((a) => a.name);
 	expect(names).toContain("app.js");
-	expect(names).toContain("page.js");
+	expect(names.filter((name) => /^__html_[0-9a-f]+_\d+\.js$/.test(name))).toHaveLength(1);
 });

--- a/test/configCases/html/iframe-srcdoc-script/index.js
+++ b/test/configCases/html/iframe-srcdoc-script/index.js
@@ -21,8 +21,9 @@ it("should bundle <script> inside <iframe srcdoc> as an entry chunk", () => {
 		ids.filter((id) => id.includes("data:text/html")).length
 	).toBeGreaterThanOrEqual(2);
 
-	// The bundled scripts become their own emitted JS chunks (named
-	// `__html_<hash>_<index>`).
+	// The bundled scripts become their own emitted JS chunks: one named after
+	// its `src`, and the inline body after the page that carries it.
 	const names = __STATS__.assets.map((a) => a.name);
-	expect(names.some((n) => /__html_[0-9a-f]+_\d+\./.test(n))).toBe(true);
+	expect(names).toContain("app.js");
+	expect(names).toContain("page.js");
 });

--- a/test/configCases/html/initial-chunk-modulepreload/test.js
+++ b/test/configCases/html/initial-chunk-modulepreload/test.js
@@ -9,7 +9,8 @@ it("should modulepreload the entry's initial dependency chunks under output.modu
 	// ESM output uses `modulepreload`, never `preload as=script`.
 	expect(page).not.toContain('rel="preload"');
 	// The entry chunk itself is not preloaded — it's already the <script src>.
-	expect(page).not.toMatch(/<link rel="modulepreload" href="__html_/);
+	expect(page).toContain('<script type="module" src="index.mjs">');
+	expect(page).not.toContain('<link rel="modulepreload" href="index.mjs">');
 });
 
 it("should place the modulepreloads inside <head>, before the body scripts", () => {

--- a/test/configCases/html/initial-chunk-prefetch/test.js
+++ b/test/configCases/html/initial-chunk-prefetch/test.js
@@ -10,5 +10,6 @@ it("should emit `<link rel=\"prefetch\">` for the entry's initial dependency chu
 	expect(page).not.toMatch(/<link rel="modulepreload"/);
 	expect(page).not.toMatch(/<link rel="preload"/);
 	// The entry chunk itself is not hinted — it's already the <script src>.
-	expect(page).not.toMatch(/<link rel="prefetch" href="__html_/);
+	expect(page).toContain('<script type="module" src="index.mjs">');
+	expect(page).not.toContain('<link rel="prefetch" href="index.mjs">');
 });

--- a/test/configCases/html/initial-chunk-preload-string/test.js
+++ b/test/configCases/html/initial-chunk-preload-string/test.js
@@ -9,5 +9,6 @@ it('should treat resourceHints: "preload" as an alias of true', () => {
 	// Classic output uses `preload`, never `modulepreload`.
 	expect(page).not.toContain("modulepreload");
 	// The entry chunk itself is not preloaded — it's already the <script src>.
-	expect(page).not.toMatch(/<link rel="preload"[^>]*href="__html_/);
+	expect(page).toContain('<script src="index.js">');
+	expect(page).not.toContain('<link rel="preload" as="script" href="index.js">');
 });

--- a/test/configCases/html/initial-chunk-preload/test.js
+++ b/test/configCases/html/initial-chunk-preload/test.js
@@ -14,7 +14,8 @@ it("should preload the entry's initial dependency chunks with <link rel=preload 
 	// Classic output uses `preload`, never `modulepreload`.
 	expect(page).not.toContain("modulepreload");
 	// The entry chunk itself is not preloaded — it's already the <script src>.
-	expect(page).not.toMatch(/<link rel="preload"[^>]*href="__html_/);
+	expect(page).toMatch(/<script[^>]*\bsrc="index\.js">/);
+	expect(page).not.toMatch(/<link rel="preload"[^>]*href="index\.js"/);
 });
 
 it("should place the preloads inside <head>, before the body scripts", () => {

--- a/test/configCases/html/inline-script-classic/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/inline-script-classic/__snapshots__/ConfigCacheTest.snap
@@ -161,9 +161,9 @@ exports[`ConfigCacheTestCases html inline-script-classic exported tests should r
 <html>
 <head>
 <title>Inline Script Classic Test</title>
-<script src=\\"__html_cbe5b59d_0.chunk.js\\"></script>
-<script src=\\"__html_cbe5b59d_1.chunk.js\\"></script>
-<script src=\\"__html_cbe5b59d_2.chunk.js\\" type=\\"text/javascript\\"></script>
+<script src=\\"page.js\\"></script>
+<script src=\\"page1.js\\"></script>
+<script src=\\"page2.js\\" type=\\"text/javascript\\"></script>
 <!-- Non-JS type stays untouched -->
 <script type=\\"application/ld+json\\">
 {\\"@context\\": \\"https://schema.org\\"}

--- a/test/configCases/html/inline-script-classic/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/inline-script-classic/__snapshots__/ConfigCacheTest.snap
@@ -161,9 +161,9 @@ exports[`ConfigCacheTestCases html inline-script-classic exported tests should r
 <html>
 <head>
 <title>Inline Script Classic Test</title>
-<script src=\\"page.js\\"></script>
-<script src=\\"page1.js\\"></script>
-<script src=\\"page2.js\\" type=\\"text/javascript\\"></script>
+<script src=\\"__html_cbe5b59d_0.js\\"></script>
+<script src=\\"__html_cbe5b59d_1.js\\"></script>
+<script src=\\"__html_cbe5b59d_2.js\\" type=\\"text/javascript\\"></script>
 <!-- Non-JS type stays untouched -->
 <script type=\\"application/ld+json\\">
 {\\"@context\\": \\"https://schema.org\\"}

--- a/test/configCases/html/inline-script-classic/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/inline-script-classic/__snapshots__/ConfigTest.snap
@@ -161,9 +161,9 @@ exports[`ConfigTestCases html inline-script-classic exported tests should rewrit
 <html>
 <head>
 <title>Inline Script Classic Test</title>
-<script src=\\"__html_cbe5b59d_0.chunk.js\\"></script>
-<script src=\\"__html_cbe5b59d_1.chunk.js\\"></script>
-<script src=\\"__html_cbe5b59d_2.chunk.js\\" type=\\"text/javascript\\"></script>
+<script src=\\"page.js\\"></script>
+<script src=\\"page1.js\\"></script>
+<script src=\\"page2.js\\" type=\\"text/javascript\\"></script>
 <!-- Non-JS type stays untouched -->
 <script type=\\"application/ld+json\\">
 {\\"@context\\": \\"https://schema.org\\"}

--- a/test/configCases/html/inline-script-classic/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/inline-script-classic/__snapshots__/ConfigTest.snap
@@ -161,9 +161,9 @@ exports[`ConfigTestCases html inline-script-classic exported tests should rewrit
 <html>
 <head>
 <title>Inline Script Classic Test</title>
-<script src=\\"page.js\\"></script>
-<script src=\\"page1.js\\"></script>
-<script src=\\"page2.js\\" type=\\"text/javascript\\"></script>
+<script src=\\"__html_cbe5b59d_0.js\\"></script>
+<script src=\\"__html_cbe5b59d_1.js\\"></script>
+<script src=\\"__html_cbe5b59d_2.js\\" type=\\"text/javascript\\"></script>
 <!-- Non-JS type stays untouched -->
 <script type=\\"application/ld+json\\">
 {\\"@context\\": \\"https://schema.org\\"}

--- a/test/configCases/html/inline-script-classic/index.js
+++ b/test/configCases/html/inline-script-classic/index.js
@@ -33,11 +33,11 @@ it("should rewrite inline <script> tags and drop `type=module` when output.modul
 	// Classic inline `<script>` (no `type`) stays without a type attribute
 	// — the auto type=module upgrade only runs when `output.module` is on.
 	expect(pageContent).toMatch(
-		/<script src="__html_[^"]+\.chunk\.js"><\/script>/
+		/<script src="page\d*\.js"><\/script>/
 	);
 	// `type="text/javascript"` stays as-is (classic-compatible).
 	expect(pageContent).toMatch(
-		/<script src="__html_[^"]+\.chunk\.js" type="text\/javascript"><\/script>/
+		/<script src="page\d*\.js" type="text\/javascript"><\/script>/
 	);
 	// `type="module"` is REMOVED — the emitted chunk is a classic IIFE,
 	// loading it under module semantics would be wrong.
@@ -52,7 +52,7 @@ it("should emit classic IIFE-wrapped chunks for inline <script> bodies", () => {
 	// First executable inline script in document order is the classic
 	// `<script>` with the `<b>hello</b>` body.
 	const classicChunkName = pageContent.match(
-		/<script src="(__html_[^"]+\.chunk\.js)"><\/script>/
+		/<script src="(page\d*\.js)"><\/script>/
 	)[1];
 	const classicChunk = readChunk(classicChunkName);
 	expect(classicChunk).toMatchSnapshot();
@@ -69,7 +69,7 @@ it("should emit IIFE-wrapped chunks for inline <script type=module> too (no outp
 	// the module-origin chunk is the second.
 	const chunkUrls = collectMatches(
 		pageContent,
-		/<script[^>]*\bsrc="(__html_[^"]+\.chunk\.js)"/g
+		/<script[^>]*\bsrc="(page\d*\.js)"/g
 	).map((m) => m[1]);
 	const moduleChunk = readChunk(chunkUrls[1]);
 	expect(moduleChunk).toMatchSnapshot();
@@ -93,7 +93,7 @@ it("should emit classic chunks for every inline-script body when output.module i
 	// level.
 	const allChunkUrls = collectMatches(
 		pageContent,
-		/<script[^>]*\bsrc="(__html_[^"]+\.chunk\.js)"/g
+		/<script[^>]*\bsrc="(page\d*\.js)"/g
 	).map((m) => m[1]);
 	expect(allChunkUrls).toHaveLength(3);
 	const chunks = allChunkUrls.map(readChunk);

--- a/test/configCases/html/inline-script-classic/index.js
+++ b/test/configCases/html/inline-script-classic/index.js
@@ -33,11 +33,11 @@ it("should rewrite inline <script> tags and drop `type=module` when output.modul
 	// Classic inline `<script>` (no `type`) stays without a type attribute
 	// — the auto type=module upgrade only runs when `output.module` is on.
 	expect(pageContent).toMatch(
-		/<script src="page\d*\.js"><\/script>/
+		/<script src="__html_[0-9a-f]+_\d+\.js"><\/script>/
 	);
 	// `type="text/javascript"` stays as-is (classic-compatible).
 	expect(pageContent).toMatch(
-		/<script src="page\d*\.js" type="text\/javascript"><\/script>/
+		/<script src="__html_[0-9a-f]+_\d+\.js" type="text\/javascript"><\/script>/
 	);
 	// `type="module"` is REMOVED — the emitted chunk is a classic IIFE,
 	// loading it under module semantics would be wrong.
@@ -52,7 +52,7 @@ it("should emit classic IIFE-wrapped chunks for inline <script> bodies", () => {
 	// First executable inline script in document order is the classic
 	// `<script>` with the `<b>hello</b>` body.
 	const classicChunkName = pageContent.match(
-		/<script src="(page\d*\.js)"><\/script>/
+		/<script src="(__html_[0-9a-f]+_\d+\.js)"><\/script>/
 	)[1];
 	const classicChunk = readChunk(classicChunkName);
 	expect(classicChunk).toMatchSnapshot();
@@ -69,7 +69,7 @@ it("should emit IIFE-wrapped chunks for inline <script type=module> too (no outp
 	// the module-origin chunk is the second.
 	const chunkUrls = collectMatches(
 		pageContent,
-		/<script[^>]*\bsrc="(page\d*\.js)"/g
+		/<script[^>]*\bsrc="(__html_[0-9a-f]+_\d+\.js)"/g
 	).map((m) => m[1]);
 	const moduleChunk = readChunk(chunkUrls[1]);
 	expect(moduleChunk).toMatchSnapshot();
@@ -93,7 +93,7 @@ it("should emit classic chunks for every inline-script body when output.module i
 	// level.
 	const allChunkUrls = collectMatches(
 		pageContent,
-		/<script[^>]*\bsrc="(page\d*\.js)"/g
+		/<script[^>]*\bsrc="(__html_[0-9a-f]+_\d+\.js)"/g
 	).map((m) => m[1]);
 	expect(allChunkUrls).toHaveLength(3);
 	const chunks = allChunkUrls.map(readChunk);

--- a/test/configCases/html/inline-script/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/inline-script/__snapshots__/ConfigCacheTest.snap
@@ -19,9 +19,9 @@ exports[`ConfigCacheTestCases html inline-script exported tests should bundle in
 <html>
 <head>
 <title>Inline Script Test</title>
-<script src=\\"__html_cbe5b59d_0.chunk.js\\" type=\\"module\\"></script>
-<script src=\\"__html_cbe5b59d_1.chunk.js\\" type=\\"module\\"></script>
-<script src=\\"__html_cbe5b59d_2.chunk.js\\" type=\\"module\\"></script>
+<script src=\\"page.mjs\\" type=\\"module\\"></script>
+<script src=\\"page1.mjs\\" type=\\"module\\"></script>
+<script src=\\"page2.mjs\\" type=\\"module\\"></script>
 <!-- Non-JS type stays untouched -->
 <script type=\\"application/ld+json\\">
 {\\"@context\\": \\"https://schema.org\\"}
@@ -32,9 +32,9 @@ exports[`ConfigCacheTestCases html inline-script exported tests should bundle in
 </head>
 <body>
 <p>Hi</p>
-<script src=\\"__html_cbe5b59d_3.chunk.js\\" type=\\"module\\"></script>
+<script src=\\"page3.mjs\\" type=\\"module\\"></script>
 <!-- A legacy JavaScript MIME essence: still executable JS, so still bundled. -->
-<script src=\\"__html_cbe5b59d_4.chunk.js\\" type=\\"module\\"></script>
+<script src=\\"page4.mjs\\" type=\\"module\\"></script>
 </body>
 </html>
 "

--- a/test/configCases/html/inline-script/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/inline-script/__snapshots__/ConfigCacheTest.snap
@@ -19,9 +19,9 @@ exports[`ConfigCacheTestCases html inline-script exported tests should bundle in
 <html>
 <head>
 <title>Inline Script Test</title>
-<script src=\\"page.mjs\\" type=\\"module\\"></script>
-<script src=\\"page1.mjs\\" type=\\"module\\"></script>
-<script src=\\"page2.mjs\\" type=\\"module\\"></script>
+<script src=\\"__html_cbe5b59d_0.mjs\\" type=\\"module\\"></script>
+<script src=\\"__html_cbe5b59d_1.mjs\\" type=\\"module\\"></script>
+<script src=\\"__html_cbe5b59d_2.mjs\\" type=\\"module\\"></script>
 <!-- Non-JS type stays untouched -->
 <script type=\\"application/ld+json\\">
 {\\"@context\\": \\"https://schema.org\\"}
@@ -32,9 +32,9 @@ exports[`ConfigCacheTestCases html inline-script exported tests should bundle in
 </head>
 <body>
 <p>Hi</p>
-<script src=\\"page3.mjs\\" type=\\"module\\"></script>
+<script src=\\"__html_cbe5b59d_3.mjs\\" type=\\"module\\"></script>
 <!-- A legacy JavaScript MIME essence: still executable JS, so still bundled. -->
-<script src=\\"page4.mjs\\" type=\\"module\\"></script>
+<script src=\\"__html_cbe5b59d_4.mjs\\" type=\\"module\\"></script>
 </body>
 </html>
 "

--- a/test/configCases/html/inline-script/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/inline-script/__snapshots__/ConfigTest.snap
@@ -19,9 +19,9 @@ exports[`ConfigTestCases html inline-script exported tests should bundle inline 
 <html>
 <head>
 <title>Inline Script Test</title>
-<script src=\\"__html_cbe5b59d_0.chunk.js\\" type=\\"module\\"></script>
-<script src=\\"__html_cbe5b59d_1.chunk.js\\" type=\\"module\\"></script>
-<script src=\\"__html_cbe5b59d_2.chunk.js\\" type=\\"module\\"></script>
+<script src=\\"page.mjs\\" type=\\"module\\"></script>
+<script src=\\"page1.mjs\\" type=\\"module\\"></script>
+<script src=\\"page2.mjs\\" type=\\"module\\"></script>
 <!-- Non-JS type stays untouched -->
 <script type=\\"application/ld+json\\">
 {\\"@context\\": \\"https://schema.org\\"}
@@ -32,9 +32,9 @@ exports[`ConfigTestCases html inline-script exported tests should bundle inline 
 </head>
 <body>
 <p>Hi</p>
-<script src=\\"__html_cbe5b59d_3.chunk.js\\" type=\\"module\\"></script>
+<script src=\\"page3.mjs\\" type=\\"module\\"></script>
 <!-- A legacy JavaScript MIME essence: still executable JS, so still bundled. -->
-<script src=\\"__html_cbe5b59d_4.chunk.js\\" type=\\"module\\"></script>
+<script src=\\"page4.mjs\\" type=\\"module\\"></script>
 </body>
 </html>
 "

--- a/test/configCases/html/inline-script/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/inline-script/__snapshots__/ConfigTest.snap
@@ -19,9 +19,9 @@ exports[`ConfigTestCases html inline-script exported tests should bundle inline 
 <html>
 <head>
 <title>Inline Script Test</title>
-<script src=\\"page.mjs\\" type=\\"module\\"></script>
-<script src=\\"page1.mjs\\" type=\\"module\\"></script>
-<script src=\\"page2.mjs\\" type=\\"module\\"></script>
+<script src=\\"__html_cbe5b59d_0.mjs\\" type=\\"module\\"></script>
+<script src=\\"__html_cbe5b59d_1.mjs\\" type=\\"module\\"></script>
+<script src=\\"__html_cbe5b59d_2.mjs\\" type=\\"module\\"></script>
 <!-- Non-JS type stays untouched -->
 <script type=\\"application/ld+json\\">
 {\\"@context\\": \\"https://schema.org\\"}
@@ -32,9 +32,9 @@ exports[`ConfigTestCases html inline-script exported tests should bundle inline 
 </head>
 <body>
 <p>Hi</p>
-<script src=\\"page3.mjs\\" type=\\"module\\"></script>
+<script src=\\"__html_cbe5b59d_3.mjs\\" type=\\"module\\"></script>
 <!-- A legacy JavaScript MIME essence: still executable JS, so still bundled. -->
-<script src=\\"page4.mjs\\" type=\\"module\\"></script>
+<script src=\\"__html_cbe5b59d_4.mjs\\" type=\\"module\\"></script>
 </body>
 </html>
 "

--- a/test/configCases/html/inline-script/index.js
+++ b/test/configCases/html/inline-script/index.js
@@ -16,7 +16,7 @@ const pageContent = typeof page === "string" ? page : "";
 
 // Document-order list of every inline-script chunk url emitted into the page.
 const scriptChunkUrls = [
-	...pageContent.matchAll(/<script[^>]*\bsrc="(page\d*\.mjs)"/g)
+	...pageContent.matchAll(/<script[^>]*\bsrc="(__html_[0-9a-f]+_\d+\.mjs)"/g)
 ].map((m) => m[1]);
 
 it("should bundle inline <script> bodies as entry chunks and rewrite their tags to `<script src>`", () => {
@@ -52,10 +52,10 @@ it("should auto-upgrade classic inline <script> to type=module when output.modul
 	// output.
 	const moduleTaggedSrcs = [
 		...pageContent.matchAll(
-			/<script[^>]*\btype="module"[^>]*\bsrc="(page\d*\.mjs)"/g
+			/<script[^>]*\btype="module"[^>]*\bsrc="(__html_[0-9a-f]+_\d+\.mjs)"/g
 		),
 		...pageContent.matchAll(
-			/<script[^>]*\bsrc="(page\d*\.mjs)"[^>]*\btype="module"/g
+			/<script[^>]*\bsrc="(__html_[0-9a-f]+_\d+\.mjs)"[^>]*\btype="module"/g
 		)
 	].map((m) => m[1]);
 	expect(new Set(moduleTaggedSrcs).size).toBe(5);

--- a/test/configCases/html/inline-script/index.js
+++ b/test/configCases/html/inline-script/index.js
@@ -16,7 +16,7 @@ const pageContent = typeof page === "string" ? page : "";
 
 // Document-order list of every inline-script chunk url emitted into the page.
 const scriptChunkUrls = [
-	...pageContent.matchAll(/<script[^>]*\bsrc="(__html_[^"]+)"/g)
+	...pageContent.matchAll(/<script[^>]*\bsrc="(page\d*\.mjs)"/g)
 ].map((m) => m[1]);
 
 it("should bundle inline <script> bodies as entry chunks and rewrite their tags to `<script src>`", () => {
@@ -52,10 +52,10 @@ it("should auto-upgrade classic inline <script> to type=module when output.modul
 	// output.
 	const moduleTaggedSrcs = [
 		...pageContent.matchAll(
-			/<script[^>]*\btype="module"[^>]*\bsrc="(__html_[^"]+)"/g
+			/<script[^>]*\btype="module"[^>]*\bsrc="(page\d*\.mjs)"/g
 		),
 		...pageContent.matchAll(
-			/<script[^>]*\bsrc="(__html_[^"]+)"[^>]*\btype="module"/g
+			/<script[^>]*\bsrc="(page\d*\.mjs)"[^>]*\btype="module"/g
 		)
 	].map((m) => m[1]);
 	expect(new Set(moduleTaggedSrcs).size).toBe(5);

--- a/test/configCases/html/link/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/link/__snapshots__/ConfigCacheTest.snap
@@ -28,8 +28,8 @@ exports[`ConfigCacheTestCases html link exported tests should handle link tag 1`
 <link rel=\\"manifest\\" href=\\"handled-manifest.webmanifest\\">
 
 <!-- Stylesheet (multi-rel parsing) -->
-<link rel=\\"stylesheet\\" href=\\"117.bundle0.css\\">
-<link rel=\\"alternate stylesheet\\" href=\\"308.bundle0.css\\" title=\\"Alternate\\">
+<link rel=\\"stylesheet\\" href=\\"style.css\\">
+<link rel=\\"alternate stylesheet\\" href=\\"alt-style.css\\" title=\\"Alternate\\">
 <!-- webpackIgnore: true -->
 <link rel=\\"stylesheet\\" href=\\"./ignored.css\\">
 
@@ -41,7 +41,7 @@ exports[`ConfigCacheTestCases html link exported tests should handle link tag 1`
 <link rel=\\"preload\\" as=\\"font\\" type=\\"font/woff2\\" crossorigin href=\\"handled-font.woff2\\">
 
 <!-- Modulepreload (resolves the JS module URL) -->
-<link rel=\\"modulepreload\\" href=\\"319.bundle0.js\\">
+<link rel=\\"modulepreload\\" href=\\"module.js\\">
 
 <!-- Itemprop link rels (only allowed itemprops trigger resolution) -->
 <link itemprop=\\"downloadUrl\\" href=\\"handled-icon.png\\">

--- a/test/configCases/html/link/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/link/__snapshots__/ConfigTest.snap
@@ -28,8 +28,8 @@ exports[`ConfigTestCases html link exported tests should handle link tag 1`] = `
 <link rel=\\"manifest\\" href=\\"handled-manifest.webmanifest\\">
 
 <!-- Stylesheet (multi-rel parsing) -->
-<link rel=\\"stylesheet\\" href=\\"117.bundle0.css\\">
-<link rel=\\"alternate stylesheet\\" href=\\"308.bundle0.css\\" title=\\"Alternate\\">
+<link rel=\\"stylesheet\\" href=\\"style.css\\">
+<link rel=\\"alternate stylesheet\\" href=\\"alt-style.css\\" title=\\"Alternate\\">
 <!-- webpackIgnore: true -->
 <link rel=\\"stylesheet\\" href=\\"./ignored.css\\">
 
@@ -41,7 +41,7 @@ exports[`ConfigTestCases html link exported tests should handle link tag 1`] = `
 <link rel=\\"preload\\" as=\\"font\\" type=\\"font/woff2\\" crossorigin href=\\"handled-font.woff2\\">
 
 <!-- Modulepreload (resolves the JS module URL) -->
-<link rel=\\"modulepreload\\" href=\\"319.bundle0.js\\">
+<link rel=\\"modulepreload\\" href=\\"module.js\\">
 
 <!-- Itemprop link rels (only allowed itemprops trigger resolution) -->
 <link itemprop=\\"downloadUrl\\" href=\\"handled-icon.png\\">

--- a/test/configCases/html/module-sibling-type/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/module-sibling-type/__snapshots__/ConfigCacheTest.snap
@@ -5,7 +5,7 @@ exports[`ConfigCacheTestCases html module-sibling-type exported tests rewrites t
 <html>
 <head>
 <title>module sibling type</title>
-<script type=\\"module\\" src=\\"html-runtime.mjs\\"></script><script type=\\"module\\" src=\\"page.mjs\\"></script>
+<script type=\\"module\\" src=\\"html-runtime.mjs\\"></script><script type=\\"module\\" src=\\"entry.mjs\\"></script>
 </head>
 <body><h1>Hello</h1></body>
 </html>

--- a/test/configCases/html/module-sibling-type/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/module-sibling-type/__snapshots__/ConfigTest.snap
@@ -5,7 +5,7 @@ exports[`ConfigTestCases html module-sibling-type exported tests rewrites type=m
 <html>
 <head>
 <title>module sibling type</title>
-<script type=\\"module\\" src=\\"html-runtime.mjs\\"></script><script type=\\"module\\" src=\\"page.mjs\\"></script>
+<script type=\\"module\\" src=\\"html-runtime.mjs\\"></script><script type=\\"module\\" src=\\"entry.mjs\\"></script>
 </head>
 <body><h1>Hello</h1></body>
 </html>

--- a/test/configCases/html/module-sibling-type/index.js
+++ b/test/configCases/html/module-sibling-type/index.js
@@ -13,7 +13,7 @@ it("rewrites type=module in place when cloning a native module <script> sibling"
 
 	// The entry chunk tag is a module script too.
 	expect(page).toMatch(
-		/<script[^>]*\btype="module"[^>]*\bsrc="[^"]*page\d*\.mjs"/
+		/<script[^>]*\btype="module"[^>]*\bsrc="entry\.mjs"/
 	);
 
 	// No unresolved source path survives.

--- a/test/configCases/html/modulepreload-esm/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/modulepreload-esm/__snapshots__/ConfigCacheTest.snap
@@ -105,15 +105,15 @@ exports[`ConfigCacheTestCases html modulepreload-esm exported tests should rewri
 <html>
 <head>
 <title>Test</title>
-<link rel=\\"modulepreload\\" href=\\"page1.mjs\\">
-<link rel=\\"modulepreload    \\" href=\\"page2.mjs\\">
-<link rel=\\"modulepreload\\" href=\\"page3.mjs\\">
+<link rel=\\"modulepreload\\" href=\\"preload.mjs\\">
+<link rel=\\"modulepreload    \\" href=\\"preload-other.mjs\\">
+<link rel=\\"modulepreload\\" href=\\"page.mjs\\">
 <!-- webpackIgnore: true -->
 <link rel=\\"modulepreload\\" href=\\"./ignored-preload.js\\">
 </head>
 <body>
 <h1>Hello</h1>
-<script type=\\"module\\" src=\\"page.mjs\\"></script>
+<script type=\\"module\\" src=\\"entry.mjs\\"></script>
 <!-- webpackIgnore: true -->
 <script type=\\"module\\" src=\\"./ignored-entry.js\\"></script>
 </body>

--- a/test/configCases/html/modulepreload-esm/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/modulepreload-esm/__snapshots__/ConfigCacheTest.snap
@@ -107,7 +107,7 @@ exports[`ConfigCacheTestCases html modulepreload-esm exported tests should rewri
 <title>Test</title>
 <link rel=\\"modulepreload\\" href=\\"preload.mjs\\">
 <link rel=\\"modulepreload    \\" href=\\"preload-other.mjs\\">
-<link rel=\\"modulepreload\\" href=\\"page.mjs\\">
+<link rel=\\"modulepreload\\" href=\\"__html_cbe5b59d_2.mjs\\">
 <!-- webpackIgnore: true -->
 <link rel=\\"modulepreload\\" href=\\"./ignored-preload.js\\">
 </head>

--- a/test/configCases/html/modulepreload-esm/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/modulepreload-esm/__snapshots__/ConfigTest.snap
@@ -105,15 +105,15 @@ exports[`ConfigTestCases html modulepreload-esm exported tests should rewrite <l
 <html>
 <head>
 <title>Test</title>
-<link rel=\\"modulepreload\\" href=\\"page1.mjs\\">
-<link rel=\\"modulepreload    \\" href=\\"page2.mjs\\">
-<link rel=\\"modulepreload\\" href=\\"page3.mjs\\">
+<link rel=\\"modulepreload\\" href=\\"preload.mjs\\">
+<link rel=\\"modulepreload    \\" href=\\"preload-other.mjs\\">
+<link rel=\\"modulepreload\\" href=\\"page.mjs\\">
 <!-- webpackIgnore: true -->
 <link rel=\\"modulepreload\\" href=\\"./ignored-preload.js\\">
 </head>
 <body>
 <h1>Hello</h1>
-<script type=\\"module\\" src=\\"page.mjs\\"></script>
+<script type=\\"module\\" src=\\"entry.mjs\\"></script>
 <!-- webpackIgnore: true -->
 <script type=\\"module\\" src=\\"./ignored-entry.js\\"></script>
 </body>

--- a/test/configCases/html/modulepreload-esm/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/modulepreload-esm/__snapshots__/ConfigTest.snap
@@ -107,7 +107,7 @@ exports[`ConfigTestCases html modulepreload-esm exported tests should rewrite <l
 <title>Test</title>
 <link rel=\\"modulepreload\\" href=\\"preload.mjs\\">
 <link rel=\\"modulepreload    \\" href=\\"preload-other.mjs\\">
-<link rel=\\"modulepreload\\" href=\\"page.mjs\\">
+<link rel=\\"modulepreload\\" href=\\"__html_cbe5b59d_2.mjs\\">
 <!-- webpackIgnore: true -->
 <link rel=\\"modulepreload\\" href=\\"./ignored-preload.js\\">
 </head>

--- a/test/configCases/html/modulepreload-esm/index.js
+++ b/test/configCases/html/modulepreload-esm/index.js
@@ -20,8 +20,8 @@ it("should rewrite <link rel=modulepreload> and <script type=module src> to chun
 	expect(page).not.toContain('href="./preload.js"');
 	expect(page).not.toContain('href="./preload-other.js"');
 	expect(page).not.toContain('src="./entry.js"');
-	expect(page).toMatch(/<link rel="modulepreload" href="page\d*\.mjs">/);
-	expect(page).toMatch(/<script type="module" src="page\d*\.mjs">/);
+	expect(page).toMatch(/<link rel="modulepreload" href="preload\.mjs">/);
+	expect(page).toMatch(/<script type="module" src="entry\.mjs">/);
 	// Data URI in modulepreload is also bundled.
 	expect(page).not.toContain('href="data:text/javascript');
 	// webpackIgnore leaves modulepreload and module-script entries untouched.
@@ -33,7 +33,7 @@ it("should rewrite <link rel=modulepreload> and <script type=module src> to chun
 
 it("should emit module-format chunks (no IIFE wrapper) when output.module is enabled", () => {
 	const preloadChunkName = chunkFor(
-		/<link rel="modulepreload" href="(page\d*\.mjs)">/
+		/<link rel="modulepreload" href="([\w-]+\.mjs)">/
 	);
 	const preloadChunk = readChunk(preloadChunkName);
 	expect(preloadChunk).toMatchSnapshot();
@@ -43,7 +43,7 @@ it("should emit module-format chunks (no IIFE wrapper) when output.module is ena
 	expect(preloadChunk).toContain('"preload module"');
 
 	const entryChunkName = chunkFor(
-		/<script type="module" src="(page\d*\.mjs)">/
+		/<script type="module" src="([\w-]+\.mjs)">/
 	);
 	const entryChunk = readChunk(entryChunkName);
 	expect(entryChunk).toMatchSnapshot();
@@ -58,10 +58,10 @@ it("should keep <link rel=modulepreload> entries independent of the module scrip
 	// module to actually run, it must import it via JS, in which case
 	// webpack inlines the module into the script chunk on its own.)
 	const preloadChunkUrls = [
-		...page.matchAll(/<link rel="modulepreload" href="(page\d*\.mjs)">/g)
+		...page.matchAll(/<link rel="modulepreload" href="([\w-]+\.mjs)">/g)
 	].map((m) => m[1]);
 	const moduleScriptUrl = chunkFor(
-		/<script type="module" src="(page\d*\.mjs)">/
+		/<script type="module" src="([\w-]+\.mjs)">/
 	);
 	expect(preloadChunkUrls.length).toBeGreaterThanOrEqual(2);
 	const moduleScriptChunk = readChunk(moduleScriptUrl);

--- a/test/configCases/html/output-html-css/test.js
+++ b/test/configCases/html/output-html-css/test.js
@@ -4,5 +4,5 @@ const path = require("path");
 it("wraps a CSS entry with only a stylesheet link, no script", () => {
 	const html = fs.readFileSync(path.resolve(__dirname, "styles.html"), "utf-8");
 	expect(html).toMatch(/<link rel="stylesheet" href="[^"]+\.css">/);
-	expect(html).not.toMatch(/__html_[^"]*\.js/);
+	expect(html).not.toContain("<script");
 });

--- a/test/configCases/html/parser-sources-custom-tag-module-siblings/index.js
+++ b/test/configCases/html/parser-sources-custom-tag-module-siblings/index.js
@@ -2,7 +2,7 @@ import page from "./page.html";
 
 it("should emit `type=module` <script> siblings for a custom `script` source under output.module", () => {
 	// The custom element's own `src` is rewritten in place to its entry chunk.
-	expect(page).toMatch(/<my-script src="page\d*\.js">/);
+	expect(page).toMatch(/<my-script src="classic\.js">/);
 	// The split-out runtime chunk is ESM (output.module), so its synthesized
 	// sibling must carry `type="module"` — a classic <script> couldn't load it.
 	expect(page).toMatch(

--- a/test/configCases/html/parser-sources-custom-tag-siblings/index.js
+++ b/test/configCases/html/parser-sources-custom-tag-siblings/index.js
@@ -2,7 +2,7 @@ import page from "./page.html";
 
 it("should emit a real classic <script> sibling (not a cloned custom element) for a `script` source with runtimeChunk", () => {
 	// The custom element's own `src` is rewritten in place to its entry chunk.
-	expect(page).toMatch(/<my-script src="page\d*\.js">/);
+	expect(page).toMatch(/<my-script src="classic\.js">/);
 	// The split-out runtime chunk is loaded by a *real* classic <script>
 	// inserted before the custom element — never a clone of <my-script>.
 	expect(page).toMatch(/<script src="[^"]*-runtime\.js"><\/script>/);
@@ -13,7 +13,7 @@ it("should emit a real classic <script> sibling (not a cloned custom element) fo
 });
 
 it("should emit a real `type=module` <script> sibling for a `script-module` source", () => {
-	expect(page).toMatch(/<my-module src="page\d*\.js">/);
+	expect(page).toMatch(/<my-module src="esm\.js">/);
 	expect(page).toMatch(
 		/<script type="module" src="[^"]*-runtime\.js"><\/script>/
 	);

--- a/test/configCases/html/parser-sources-custom/index.js
+++ b/test/configCases/html/parser-sources-custom/index.js
@@ -21,10 +21,8 @@ it("should match a tagless entry against any element", () => {
 });
 
 it("should not promote custom sources into compilation entries", () => {
-	// Even if a user adds `{ tag: 'script', attribute: 'src', type: 'src' }`
-	// without `'...'`, it should be a plain URL rewrite — never a chunk
-	// entry. That's verified here by the absence of `__html_*` chunk
-	// names in the rewritten HTML; the custom-source `data-src` /
-	// `data-srcset` / `data-href` URLs are asset URLs, not script chunks.
-	expect(page).not.toMatch(/__html_[a-f0-9]+_\d+/);
+	// A custom source without `'...'` is a plain URL rewrite, so the page
+	// gains no chunk named after it — every rewritten URL is an asset one.
+	expect(page).not.toMatch(/"page\d*\.js"/);
+	expect(__STATS__.assets.map((a) => a.name)).not.toContain("page.js");
 });

--- a/test/configCases/html/parser-sources-disabled/index.js
+++ b/test/configCases/html/parser-sources-disabled/index.js
@@ -17,7 +17,7 @@ it("should not let Object.prototype-named tags bypass sources:false", () => {
 	// to an inherited value and never becomes a chunk entry (the file
 	// doesn't exist; a bogus entry would fail the build).
 	expect(page).toContain('name="./proto-bypass.js"');
-	expect(page).not.toMatch(/__html_[a-f0-9]+_\d+/);
+	expect(page).not.toMatch(/name="page\d*\.js"/);
 });
 
 it("should still bundle inline <script> bodies when sources is false", () => {

--- a/test/configCases/html/parser-sources-html-shared-assets/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/parser-sources-html-shared-assets/__snapshots__/ConfigCacheTest.snap
@@ -3,10 +3,10 @@
 exports[`ConfigCacheTestCases html parser-sources-html-shared-assets exported tests handles a script and stylesheet shared between the two pages 1`] = `
 "<!DOCTYPE html>
 <html>
-<head><link rel=\\"stylesheet\\" href=\\"315.bundle0.css\\"></head>
+<head><link rel=\\"stylesheet\\" href=\\"shared1.css\\"></head>
 <body>
 <h1>About</h1>
-<script src=\\"666.bundle0.js\\"></script>
+<script src=\\"shared1.js\\"></script>
 </body>
 </html>
 "

--- a/test/configCases/html/parser-sources-html-shared-assets/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/parser-sources-html-shared-assets/__snapshots__/ConfigTest.snap
@@ -3,10 +3,10 @@
 exports[`ConfigTestCases html parser-sources-html-shared-assets exported tests handles a script and stylesheet shared between the two pages 1`] = `
 "<!DOCTYPE html>
 <html>
-<head><link rel=\\"stylesheet\\" href=\\"315.bundle0.css\\"></head>
+<head><link rel=\\"stylesheet\\" href=\\"shared1.css\\"></head>
 <body>
 <h1>About</h1>
-<script src=\\"666.bundle0.js\\"></script>
+<script src=\\"shared1.js\\"></script>
 </body>
 </html>
 "

--- a/test/configCases/html/parser-sources-types/index.js
+++ b/test/configCases/html/parser-sources-types/index.js
@@ -4,19 +4,19 @@ it("should bundle a `script`-typed attribute as a classic chunk entry", () => {
 	// `./classic.js` was bundled into a chunk; the original `<my-script
 	// src="./classic.js">` was rewritten to point at it.
 	expect(page).not.toContain('src="./classic.js"');
-	expect(page).toMatch(/<my-script src="page\d*\.js">/);
+	expect(page).toMatch(/<my-script src="classic\.js">/);
 });
 
 it("should bundle a `script-module`-typed attribute as an ESM chunk entry", () => {
 	expect(page).not.toContain('src="./esm.js"');
-	expect(page).toMatch(/<my-module src="page\d*\.js">/);
+	expect(page).toMatch(/<my-module src="esm\.js">/);
 });
 
 it("should bundle a `stylesheet`-typed attribute as a CSS chunk entry", () => {
 	// `./styles.css` flowed through the CSS pipeline; the custom tag's
 	// `href` now points at the emitted `.css` chunk, not the source.
 	expect(page).not.toContain('href="./styles.css"');
-	expect(page).toMatch(/<my-link href="page\d*\.css">/);
+	expect(page).toMatch(/<my-link href="styles\.css">/);
 });
 
 it("should bundle a `stylesheet-style`-typed attribute value as inline CSS", () => {

--- a/test/configCases/html/preload-prefetch-asset/index.js
+++ b/test/configCases/html/preload-prefetch-asset/index.js
@@ -28,7 +28,10 @@ it("should rewrite <link rel=preload/prefetch> of asset-module targets to asset 
 	);
 
 	// No chunk was emitted for a resource hint — these are plain assets.
-	expect(page).not.toContain("__html_");
+	expect(page).not.toContain("<script");
+	expect(fs.readdirSync(__dirname).filter((n) => n.endsWith(".js"))).toEqual([
+		"main.js"
+	]);
 });
 
 it("should emit each referenced asset to disk", () => {

--- a/test/configCases/html/preload-prefetch-shared/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/preload-prefetch-shared/__snapshots__/ConfigCacheTest.snap
@@ -6,14 +6,14 @@ exports[`ConfigCacheTestCases html preload-prefetch-shared exported tests should
 <head>
 <title>Test</title>
 <!-- \`shared.js\` is a real executing entry AND preloaded/prefetched. -->
-<link rel=\\"preload\\" as=\\"script\\" href=\\"page1.js\\">
-<link rel=\\"prefetch\\" as=\\"script\\" href=\\"page3.js\\">
+<link rel=\\"preload\\" as=\\"script\\" href=\\"shared.js\\">
+<link rel=\\"prefetch\\" as=\\"script\\" href=\\"shared1.js\\">
 <!-- \`used.js\` is preloaded but only ever imported from code. -->
-<link rel=\\"preload\\" as=\\"script\\" href=\\"page2.js\\">
+<link rel=\\"preload\\" as=\\"script\\" href=\\"used.js\\">
 </head>
 <body>
 <h1>Hello</h1>
-<script src=\\"page.js\\"></script>
+<script src=\\"shared2.js\\"></script>
 </body>
 </html>
 "

--- a/test/configCases/html/preload-prefetch-shared/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/preload-prefetch-shared/__snapshots__/ConfigTest.snap
@@ -6,14 +6,14 @@ exports[`ConfigTestCases html preload-prefetch-shared exported tests should buil
 <head>
 <title>Test</title>
 <!-- \`shared.js\` is a real executing entry AND preloaded/prefetched. -->
-<link rel=\\"preload\\" as=\\"script\\" href=\\"page1.js\\">
-<link rel=\\"prefetch\\" as=\\"script\\" href=\\"page3.js\\">
+<link rel=\\"preload\\" as=\\"script\\" href=\\"shared.js\\">
+<link rel=\\"prefetch\\" as=\\"script\\" href=\\"shared1.js\\">
 <!-- \`used.js\` is preloaded but only ever imported from code. -->
-<link rel=\\"preload\\" as=\\"script\\" href=\\"page2.js\\">
+<link rel=\\"preload\\" as=\\"script\\" href=\\"used.js\\">
 </head>
 <body>
 <h1>Hello</h1>
-<script src=\\"page.js\\"></script>
+<script src=\\"shared2.js\\"></script>
 </body>
 </html>
 "

--- a/test/configCases/html/preload-prefetch-shared/index.js
+++ b/test/configCases/html/preload-prefetch-shared/index.js
@@ -8,13 +8,13 @@ it("should build a preload/prefetch target that is also used in code and as a re
 
 	// The real `<script src>` entry is rewritten to its chunk URL.
 	expect(page).not.toContain('src="./shared.js"');
-	expect(page).toMatch(/<script src="page\d*\.js"><\/script>/);
+	expect(page).toMatch(/<script src="shared\d*\.js"><\/script>/);
 
 	// Both the preload and prefetch of `shared.js` are rewritten to chunk
 	// URLs — an entry being preloaded is not a conflict.
 	expect(page).not.toContain('href="./shared.js"');
-	expect(page).toMatch(/<link rel="preload" as="script" href="page\d*\.js">/);
-	expect(page).toMatch(/<link rel="prefetch" as="script" href="page\d*\.js">/);
+	expect(page).toMatch(/<link rel="preload" as="script" href="shared\d*\.js">/);
+	expect(page).toMatch(/<link rel="prefetch" as="script" href="shared\d*\.js">/);
 
 	// `used.js` is preloaded and also imported from code — its hint is
 	// still rewritten to a chunk URL.

--- a/test/configCases/html/preload-prefetch/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/preload-prefetch/__snapshots__/ConfigCacheTest.snap
@@ -5,9 +5,9 @@ exports[`ConfigCacheTestCases html preload-prefetch exported tests should rewrit
 <html>
 <head>
 <title>Test</title>
-<link rel=\\"preload\\" as=\\"script\\" href=\\"page.js\\">
-<link rel=\\"prefetch\\" as=\\"script\\" href=\\"page1.js\\">
-<link rel=\\"preload\\" as=\\"style\\" href=\\"page.css\\">
+<link rel=\\"preload\\" as=\\"script\\" href=\\"preload-script.js\\">
+<link rel=\\"prefetch\\" as=\\"script\\" href=\\"prefetch-script.js\\">
+<link rel=\\"preload\\" as=\\"style\\" href=\\"preload-style.css\\">
 <!-- webpackIgnore: true -->
 <link rel=\\"preload\\" as=\\"script\\" href=\\"./ignored.js\\">
 </head>

--- a/test/configCases/html/preload-prefetch/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/preload-prefetch/__snapshots__/ConfigTest.snap
@@ -5,9 +5,9 @@ exports[`ConfigTestCases html preload-prefetch exported tests should rewrite <li
 <html>
 <head>
 <title>Test</title>
-<link rel=\\"preload\\" as=\\"script\\" href=\\"page.js\\">
-<link rel=\\"prefetch\\" as=\\"script\\" href=\\"page1.js\\">
-<link rel=\\"preload\\" as=\\"style\\" href=\\"page.css\\">
+<link rel=\\"preload\\" as=\\"script\\" href=\\"preload-script.js\\">
+<link rel=\\"prefetch\\" as=\\"script\\" href=\\"prefetch-script.js\\">
+<link rel=\\"preload\\" as=\\"style\\" href=\\"preload-style.css\\">
 <!-- webpackIgnore: true -->
 <link rel=\\"preload\\" as=\\"script\\" href=\\"./ignored.js\\">
 </head>

--- a/test/configCases/html/preload-prefetch/index.js
+++ b/test/configCases/html/preload-prefetch/index.js
@@ -8,16 +8,16 @@ it("should rewrite <link rel=preload/prefetch> of a bundled script/style to chun
 	expect(page).not.toContain('href="./preload-script.js"');
 	expect(page).not.toContain('href="./prefetch-script.js"');
 	expect(page).toMatch(
-		/<link rel="preload" as="script" href="page\d*\.js">/
+		/<link rel="preload" as="script" href="preload-script\.js">/
 	);
 	expect(page).toMatch(
-		/<link rel="prefetch" as="script" href="page\d*\.js">/
+		/<link rel="prefetch" as="script" href="prefetch-script\.js">/
 	);
 
 	// `as="style"` preload → CSS chunk URL.
 	expect(page).not.toContain('href="./preload-style.css"');
 	expect(page).toMatch(
-		/<link rel="preload" as="style" href="page\d*\.css">/
+		/<link rel="preload" as="style" href="preload-style\.css">/
 	);
 
 	// `webpackIgnore` leaves the resource hint untouched.

--- a/test/configCases/html/script-src-classic/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/script-src-classic/__snapshots__/ConfigCacheTest.snap
@@ -170,12 +170,12 @@ exports[`ConfigCacheTestCases html script-src-classic exported tests should rewr
 <html>
 <head>
 <title>Classic-output test</title>
-<script src=\\"__html_cbe5b59d_0.chunk.js\\"></script>
+<script src=\\"entry.js\\"></script>
 </head>
 <body>
-<script src=\\"__html_cbe5b59d_1.chunk.js\\"></script>
-<script type=\\"text/javascript\\" src=\\"__html_cbe5b59d_2.chunk.js\\"></script>
-<script src=\\"__html_cbe5b59d_3.chunk.js\\"></script>
+<script src=\\"other.js\\"></script>
+<script type=\\"text/javascript\\" src=\\"classic-typed.js\\"></script>
+<script src=\\"module-entry.js\\"></script>
 <script type=\\"application/ld+json\\" src=\\"1aeae0731d54e523748c.jsonld\\"></script>
 </body>
 </html>

--- a/test/configCases/html/script-src-classic/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/script-src-classic/__snapshots__/ConfigTest.snap
@@ -170,12 +170,12 @@ exports[`ConfigTestCases html script-src-classic exported tests should rewrite s
 <html>
 <head>
 <title>Classic-output test</title>
-<script src=\\"__html_cbe5b59d_0.chunk.js\\"></script>
+<script src=\\"entry.js\\"></script>
 </head>
 <body>
-<script src=\\"__html_cbe5b59d_1.chunk.js\\"></script>
-<script type=\\"text/javascript\\" src=\\"__html_cbe5b59d_2.chunk.js\\"></script>
-<script src=\\"__html_cbe5b59d_3.chunk.js\\"></script>
+<script src=\\"other.js\\"></script>
+<script type=\\"text/javascript\\" src=\\"classic-typed.js\\"></script>
+<script src=\\"module-entry.js\\"></script>
 <script type=\\"application/ld+json\\" src=\\"1aeae0731d54e523748c.jsonld\\"></script>
 </body>
 </html>

--- a/test/configCases/html/script-src-classic/index.js
+++ b/test/configCases/html/script-src-classic/index.js
@@ -24,10 +24,10 @@ it("should rewrite script src attributes without changing the type attribute whe
 	expect(page).not.toContain('src="./module-entry.js"');
 	// Classic <script src> (no type) stays without a type attribute — the
 	// auto type=module upgrade only runs when output.module is enabled.
-	expect(page).toMatch(/<script src="__html_[^"]+\.chunk\.js">/);
+	expect(page).toMatch(/<script src="entry\.js">/);
 	// type="text/javascript" stays as-is too (classic-compatible).
 	expect(page).toMatch(
-		/<script type="text\/javascript" src="__html_[^"]+\.chunk\.js">/
+		/<script type="text\/javascript" src="classic-typed\.js">/
 	);
 	// type="module" is REMOVED — the emitted chunk is a classic IIFE,
 	// loading it under module semantics would be wrong.
@@ -37,9 +37,9 @@ it("should rewrite script src attributes without changing the type attribute whe
 });
 
 it("should emit classic IIFE-wrapped chunks for <script src>", () => {
-	// The first classic <script src> chunk lives at __html_*_0.chunk.js.
+	// The first classic <script src> chunk lives at entry.js.
 	const classicChunkName = page.match(
-		/<script src="(__html_[^"]+\.chunk\.js)">/
+		/<script src="(entry\.js)">/
 	)[1];
 	const classicChunk = readChunk(classicChunkName);
 	expect(classicChunk).toMatchSnapshot();
@@ -56,7 +56,7 @@ it("should emit IIFE-wrapped chunks for <script type=module src> too (still vali
 	// chunk by tag shape anymore — find it by content instead.
 	const allChunkUrls = collectMatches(
 		page,
-		/<script[^>]*\bsrc="(__html_[^"]+\.chunk\.js)"/g
+		/<script[^>]*\bsrc="([\w-]+\.js)"/g
 	).map((m) => m[1]);
 	const moduleChunk = allChunkUrls
 		.map(readChunk)

--- a/test/configCases/html/script-src-mixed/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/script-src-mixed/__snapshots__/ConfigCacheTest.snap
@@ -5,12 +5,12 @@ exports[`ConfigCacheTestCases html script-src-mixed exported tests should bundle
 <html>
 <head>
 <title>Mixed scripts</title>
-<script type=\\"module\\" src=\\"__html_cbe5b59d_0.chunk.js\\"></script>
-<script type=\\"module\\" src=\\"__html_cbe5b59d_1.chunk.js\\"></script>
+<script type=\\"module\\" src=\\"classic-a.mjs\\"></script>
+<script type=\\"module\\" src=\\"module-a.mjs\\"></script>
 </head>
 <body>
-<script type=\\"module\\" src=\\"__html_cbe5b59d_2.chunk.js\\"></script>
-<script type=\\"module\\" src=\\"__html_cbe5b59d_3.chunk.js\\"></script>
+<script type=\\"module\\" src=\\"classic-b.mjs\\"></script>
+<script type=\\"module\\" src=\\"module-b.mjs\\"></script>
 </body>
 </html>
 "
@@ -180,7 +180,7 @@ globalThis.__moduleB = \`module-b sees: \${_module_a_js__WEBPACK_IMPORTED_MODULE
 ;
 
 // load runtime
-import { __webpack_require__ } from \\"./__html_cbe5b59d_1.chunk.js\\";
+import { __webpack_require__ } from \\"./module-a.mjs\\";
 var __webpack_exec__ = (moduleId) => (__webpack_require__(moduleId))
 __webpack_require__.C({ __webpack_esm_ids__, __webpack_esm_modules__ });
 var __webpack_exports__ = __webpack_exec__(942);
@@ -308,7 +308,7 @@ globalThis.__classicB = \\"classic-b value\\";
 ;
 
 // load runtime
-import { __webpack_require__ } from \\"./__html_cbe5b59d_0.chunk.js\\";
+import { __webpack_require__ } from \\"./classic-a.mjs\\";
 var __webpack_exec__ = (moduleId) => (__webpack_require__(moduleId))
 __webpack_require__.C({ __webpack_esm_ids__, __webpack_esm_modules__ });
 var __webpack_exports__ = __webpack_exec__(702);

--- a/test/configCases/html/script-src-mixed/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/script-src-mixed/__snapshots__/ConfigTest.snap
@@ -5,12 +5,12 @@ exports[`ConfigTestCases html script-src-mixed exported tests should bundle mult
 <html>
 <head>
 <title>Mixed scripts</title>
-<script type=\\"module\\" src=\\"__html_cbe5b59d_0.chunk.js\\"></script>
-<script type=\\"module\\" src=\\"__html_cbe5b59d_1.chunk.js\\"></script>
+<script type=\\"module\\" src=\\"classic-a.mjs\\"></script>
+<script type=\\"module\\" src=\\"module-a.mjs\\"></script>
 </head>
 <body>
-<script type=\\"module\\" src=\\"__html_cbe5b59d_2.chunk.js\\"></script>
-<script type=\\"module\\" src=\\"__html_cbe5b59d_3.chunk.js\\"></script>
+<script type=\\"module\\" src=\\"classic-b.mjs\\"></script>
+<script type=\\"module\\" src=\\"module-b.mjs\\"></script>
 </body>
 </html>
 "
@@ -180,7 +180,7 @@ globalThis.__moduleB = \`module-b sees: \${_module_a_js__WEBPACK_IMPORTED_MODULE
 ;
 
 // load runtime
-import { __webpack_require__ } from \\"./__html_cbe5b59d_1.chunk.js\\";
+import { __webpack_require__ } from \\"./module-a.mjs\\";
 var __webpack_exec__ = (moduleId) => (__webpack_require__(moduleId))
 __webpack_require__.C({ __webpack_esm_ids__, __webpack_esm_modules__ });
 var __webpack_exports__ = __webpack_exec__(942);
@@ -308,7 +308,7 @@ globalThis.__classicB = \\"classic-b value\\";
 ;
 
 // load runtime
-import { __webpack_require__ } from \\"./__html_cbe5b59d_0.chunk.js\\";
+import { __webpack_require__ } from \\"./classic-a.mjs\\";
 var __webpack_exec__ = (moduleId) => (__webpack_require__(moduleId))
 __webpack_require__.C({ __webpack_esm_ids__, __webpack_esm_modules__ });
 var __webpack_exports__ = __webpack_exec__(702);

--- a/test/configCases/html/script-src-mixed/index.js
+++ b/test/configCases/html/script-src-mixed/index.js
@@ -13,7 +13,7 @@ const readChunk = (name) => fs.readFileSync(path.resolve(here, name), "utf-8");
 // emitted HTML looks the same. The four chunks appear in document order:
 // classic-a, module-a, classic-b, module-b.
 const scriptChunkUrls = [
-	...page.matchAll(/<script[^>]*\bsrc="(__html_[^"]+\.chunk\.js)">/g)
+	...page.matchAll(/<script[^>]*\bsrc="([\w-]+\.mjs)">/g)
 ].map((m) => m[1]);
 
 const chunkContaining = (substr) =>

--- a/test/configCases/html/script-src/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/script-src/__snapshots__/ConfigCacheTest.snap
@@ -139,8 +139,8 @@ exports[`ConfigCacheTestCases html script-src exported tests should bundle class
 <script type=\\"module\\" src=\\"other.mjs\\"></script>
 <script type=\\"module\\" src=\\"module-entry.mjs\\"></script>
 <script type=\\"module\\" src=\\"classic-typed.mjs\\"></script>
-<script type=\\"module\\" src=\\"page.mjs\\"></script>
-<script type=\\"module\\" src=\\"page1.mjs\\"></script>
+<script type=\\"module\\" src=\\"__html_cbe5b59d_4.mjs\\"></script>
+<script type=\\"module\\" src=\\"__html_cbe5b59d_5.mjs\\"></script>
 <!-- Non-JS script types must NOT be bundled as JS entries. They flow
      through the regular HtmlSourceDependency path: rewritten as an
      asset URL, the attribute stays as-is. -->

--- a/test/configCases/html/script-src/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/script-src/__snapshots__/ConfigCacheTest.snap
@@ -132,15 +132,15 @@ exports[`ConfigCacheTestCases html script-src exported tests should bundle class
 <title>Test</title>
 <link rel=\\"stylesheet\\" href=\\"a69243d21de4c981a8a4.css\\">
 <link rel=\\"icon\\" href=\\"31d6cfe0d16ae931b73c.png\\">
-<script type=\\"module\\" src=\\"__html_cbe5b59d_0.chunk.js\\"></script>
+<script type=\\"module\\" src=\\"entry.mjs\\"></script>
 </head>
 <body>
 <h1>Hello</h1>
-<script type=\\"module\\" src=\\"__html_cbe5b59d_1.chunk.js\\"></script>
-<script type=\\"module\\" src=\\"__html_cbe5b59d_2.chunk.js\\"></script>
-<script type=\\"module\\" src=\\"__html_cbe5b59d_3.chunk.js\\"></script>
-<script type=\\"module\\" src=\\"__html_cbe5b59d_4.chunk.js\\"></script>
-<script type=\\"module\\" src=\\"__html_cbe5b59d_5.chunk.js\\"></script>
+<script type=\\"module\\" src=\\"other.mjs\\"></script>
+<script type=\\"module\\" src=\\"module-entry.mjs\\"></script>
+<script type=\\"module\\" src=\\"classic-typed.mjs\\"></script>
+<script type=\\"module\\" src=\\"page.mjs\\"></script>
+<script type=\\"module\\" src=\\"page1.mjs\\"></script>
 <!-- Non-JS script types must NOT be bundled as JS entries. They flow
      through the regular HtmlSourceDependency path: rewritten as an
      asset URL, the attribute stays as-is. -->

--- a/test/configCases/html/script-src/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/script-src/__snapshots__/ConfigTest.snap
@@ -132,15 +132,15 @@ exports[`ConfigTestCases html script-src exported tests should bundle classic an
 <title>Test</title>
 <link rel=\\"stylesheet\\" href=\\"a69243d21de4c981a8a4.css\\">
 <link rel=\\"icon\\" href=\\"31d6cfe0d16ae931b73c.png\\">
-<script type=\\"module\\" src=\\"__html_cbe5b59d_0.chunk.js\\"></script>
+<script type=\\"module\\" src=\\"entry.mjs\\"></script>
 </head>
 <body>
 <h1>Hello</h1>
-<script type=\\"module\\" src=\\"__html_cbe5b59d_1.chunk.js\\"></script>
-<script type=\\"module\\" src=\\"__html_cbe5b59d_2.chunk.js\\"></script>
-<script type=\\"module\\" src=\\"__html_cbe5b59d_3.chunk.js\\"></script>
-<script type=\\"module\\" src=\\"__html_cbe5b59d_4.chunk.js\\"></script>
-<script type=\\"module\\" src=\\"__html_cbe5b59d_5.chunk.js\\"></script>
+<script type=\\"module\\" src=\\"other.mjs\\"></script>
+<script type=\\"module\\" src=\\"module-entry.mjs\\"></script>
+<script type=\\"module\\" src=\\"classic-typed.mjs\\"></script>
+<script type=\\"module\\" src=\\"page.mjs\\"></script>
+<script type=\\"module\\" src=\\"page1.mjs\\"></script>
 <!-- Non-JS script types must NOT be bundled as JS entries. They flow
      through the regular HtmlSourceDependency path: rewritten as an
      asset URL, the attribute stays as-is. -->

--- a/test/configCases/html/script-src/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/script-src/__snapshots__/ConfigTest.snap
@@ -139,8 +139,8 @@ exports[`ConfigTestCases html script-src exported tests should bundle classic an
 <script type=\\"module\\" src=\\"other.mjs\\"></script>
 <script type=\\"module\\" src=\\"module-entry.mjs\\"></script>
 <script type=\\"module\\" src=\\"classic-typed.mjs\\"></script>
-<script type=\\"module\\" src=\\"page.mjs\\"></script>
-<script type=\\"module\\" src=\\"page1.mjs\\"></script>
+<script type=\\"module\\" src=\\"__html_cbe5b59d_4.mjs\\"></script>
+<script type=\\"module\\" src=\\"__html_cbe5b59d_5.mjs\\"></script>
 <!-- Non-JS script types must NOT be bundled as JS entries. They flow
      through the regular HtmlSourceDependency path: rewritten as an
      asset URL, the attribute stays as-is. -->

--- a/test/configCases/html/script-src/index.js
+++ b/test/configCases/html/script-src/index.js
@@ -13,7 +13,7 @@ const readChunk = (name) => fs.readFileSync(path.resolve(here, name), "utf-8");
 // (because `output.module` is on), so they look identical to native module
 // scripts in HTML; we discriminate by chunk content instead of by tag shape.
 const scriptChunkUrls = [
-	...page.matchAll(/<script[^>]*\bsrc="(__html_[^"]+)">/g)
+	...page.matchAll(/<script[^>]*\bsrc="([\w-]+\.mjs)">/g)
 ].map((m) => m[1]);
 
 it("should bundle classic and module <script src> as separate entry chunks and rewrite their src attributes", () => {
@@ -40,7 +40,7 @@ it("should bundle classic and module <script src> as separate entry chunks and r
 	// `output.module` is on in this fixture; the existing `type="text/javascript"`
 	// is upgraded in place to `type="module"` for the same reason.
 	expect(page).not.toContain('type="text/javascript"');
-	expect(page).not.toContain('<script src="__html_');
+	expect(page).not.toMatch(/<script src="[\w-]+\.mjs">/);
 });
 
 it("should bundle <script src=data:...> inline JS into chunks", () => {

--- a/test/configCases/html/script-type-unquoted/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/script-type-unquoted/__snapshots__/ConfigCacheTest.snap
@@ -5,7 +5,7 @@ exports[`ConfigCacheTestCases html script-type-unquoted exported tests should st
 <html>
 <head><title>script-type-unquoted</title></head>
 <body>
-<script src=\\"117.bundle0.js\\"></script>
+<script src=\\"entry.js\\"></script>
 </body>
 </html>
 "

--- a/test/configCases/html/script-type-unquoted/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/script-type-unquoted/__snapshots__/ConfigTest.snap
@@ -5,7 +5,7 @@ exports[`ConfigTestCases html script-type-unquoted exported tests should strip u
 <html>
 <head><title>script-type-unquoted</title></head>
 <body>
-<script src=\\"117.bundle0.js\\"></script>
+<script src=\\"entry.js\\"></script>
 </body>
 </html>
 "

--- a/test/configCases/html/script-types/index.js
+++ b/test/configCases/html/script-types/index.js
@@ -12,7 +12,7 @@ it("should bundle every executable JavaScript script type", () => {
 	expect(matches(/window\.__t\d+/g)).toEqual([]);
 
 	// Every one became its own entry chunk instead.
-	expect(matches(/<script[^>]*\bsrc="__html_[^"]+"/g)).toHaveLength(18);
+	expect(matches(/<script[^>]*\bsrc="[\w-]+\d*\.js"/g)).toHaveLength(18);
 });
 
 it("should leave a data block inline", () => {

--- a/test/configCases/html/svg-script-href/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/svg-script-href/__snapshots__/ConfigCacheTest.snap
@@ -7,11 +7,11 @@ exports[`ConfigCacheTestCases html svg-script-href exported tests should bundle 
 <body>
 
 <svg width=\\"10\\" height=\\"10\\">
-	<script xlink:href=\\"__html_cbe5b59d_0.chunk.js\\"></script>
+	<script xlink:href=\\"entry.js\\"></script>
 </svg>
 
 <svg width=\\"10\\" height=\\"10\\">
-	<script href=\\"__html_cbe5b59d_1.chunk.js\\">console.log(\\"fallback ignored when href is present\\")</script>
+	<script href=\\"entry2.js\\">console.log(\\"fallback ignored when href is present\\")</script>
 </svg>
 
 </body>

--- a/test/configCases/html/svg-script-href/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/svg-script-href/__snapshots__/ConfigTest.snap
@@ -7,11 +7,11 @@ exports[`ConfigTestCases html svg-script-href exported tests should bundle SVG <
 <body>
 
 <svg width=\\"10\\" height=\\"10\\">
-	<script xlink:href=\\"__html_cbe5b59d_0.chunk.js\\"></script>
+	<script xlink:href=\\"entry.js\\"></script>
 </svg>
 
 <svg width=\\"10\\" height=\\"10\\">
-	<script href=\\"__html_cbe5b59d_1.chunk.js\\">console.log(\\"fallback ignored when href is present\\")</script>
+	<script href=\\"entry2.js\\">console.log(\\"fallback ignored when href is present\\")</script>
 </svg>
 
 </body>

--- a/test/configCases/html/svg-script-href/index.js
+++ b/test/configCases/html/svg-script-href/index.js
@@ -3,8 +3,8 @@ import page from "./page.html";
 it("should bundle SVG <script xlink:href> and <script href> as entry chunks", () => {
 	expect(page).not.toContain("./entry.js");
 	expect(page).not.toContain("./entry2.js");
-	expect(page).toMatch(/<script xlink:href="__html_[^"]+\.chunk\.js">/);
-	expect(page).toMatch(/<script href="__html_[^"]+\.chunk\.js">/);
+	expect(page).toMatch(/<script xlink:href="entry\.js">/);
+	expect(page).toMatch(/<script href="entry2\.js">/);
 	expect(page).toMatchSnapshot();
 });
 

--- a/test/watchCases/long-term-caching/html-contenthash-inline-script/0/index.js
+++ b/test/watchCases/long-term-caching/html-contenthash-inline-script/0/index.js
@@ -4,7 +4,7 @@ const fs = __non_webpack_require__("fs");
 const path = __non_webpack_require__("path");
 
 const findInlineEntry = (assets) =>
-	assets.find((a) => /^page\./.test(a.name) && /\.js$/.test(a.name));
+	assets.find((a) => /^__html_[0-9a-f]+_\d+\./.test(a.name) && /\.js$/.test(a.name));
 
 it("should compile fine and emit the extracted HTML and the inline-script entry chunk", () => {
 	const htmlAsset = STATS_JSON.assets.find((a) => /\.html$/.test(a.name));

--- a/test/watchCases/long-term-caching/html-contenthash-inline-script/1/index.js
+++ b/test/watchCases/long-term-caching/html-contenthash-inline-script/1/index.js
@@ -6,7 +6,7 @@ const path = __non_webpack_require__("path");
 const findInlineEntry = (assets) =>
 	assets.find(
 		(a) =>
-			/^page\./.test(a.name) &&
+			/^__html_[0-9a-f]+_\d+\./.test(a.name) &&
 			/\.js$/.test(a.name) &&
 			a.name !== STATE.inlineEntryName
 	);

--- a/types.d.ts
+++ b/types.d.ts
@@ -10421,6 +10421,7 @@ declare interface HtmlEmittedContext {
 declare interface HtmlEntryInfo {
 	request: string;
 	entryName: string;
+	index: number;
 	type:
 		| "html"
 		| "script"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

The entries a page's `<script src>` / `<link rel="stylesheet">` become are entry points, but they were emitted through `output.chunkFilename` under the synthetic name the parser gave them, so `output.filename: "bundle.js"` (or a function, or `[id].css`) leaked `__html_<hash>_<index>.bundle.js` into user-visible filenames. They now emit through `output.filename` / `output.cssFilename` with `[name]` taken from the tag's url — `src="./my-script.js"` emits `my-script.js` — and a template that names no chunk lends its directory and extension to a `[name]` instead of leaking that id. A name another entry already emits is numbered past it, an inline body (no url) keeps its page's name, and an `output.html` wrapper stays named after the entry it wraps.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — new `test/configCases/html/extracted-entry-filenames{,-function}`, plus updated expectations in `html-linked-page-name`, `html-imported-page-name`, `html-linked-page-name-taken` (rewritten to exercise a real collision) and the `script-src*` / `inline-script*` / `initial-chunk-*` cases.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No, `experiments.html` is experimental — but the filenames emitted for a page's scripts and stylesheets change, so anything pinning the old synthetic names needs no migration beyond reading the new ones.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

The naming rule for HTML entry points: `[name]` comes from the tag's url, falling back to the page's name for an inline body, with a numeric suffix on collision.

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

AI was used, via Claude Code: it verified the current naming across ~30 build configurations, implemented the change in `lib/html/`, wrote and updated the test cases, and ran the html suites and `yarn lint`. Every reported filename in the summary comes from a real build, and the behaviour was reviewed and directed by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018x1kaMhMLU14bbYw4yQ2Ux

---
_Generated by [Claude Code](https://claude.ai/code/session_018x1kaMhMLU14bbYw4yQ2Ux)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - HTML-generated JavaScript and CSS assets now use stable names based on referenced URLs and configured filename templates.
  - Linked, inline, preload, and module assets receive consistent filenames.
  - Extracted entries are named in document order for deterministic output.
  - Inline iframe content inherits the embedding page’s filename.
  - Shared and cyclic linked pages are handled without duplicate output.

- **Bug Fixes**
  - Name conflicts receive numbered alternatives.
  - HTML references and resource hints point to the correct emitted assets.
  - CSS-only pages are emitted without script tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->