### PR TITLE
build: drop lockfile-lint from lint:special

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "prelint": "yarn setup",
     "lint": "yarn lint:code && yarn lint:special && yarn lint:types && yarn lint:types-test && yarn lint:types-benchmark && yarn lint:types-module-test && yarn lint:types-hot && yarn fmt:check && yarn lint:spellcheck",
     "lint:code": "node node_modules/eslint/bin/eslint.js --cache .",
-    "lint:special": "node node_modules/tooling/lockfile-lint && node node_modules/tooling/inherit-types && node tooling/generate-runtime-code.js && node tooling/generate-wasm-code.js && node tooling/generate-css-data.js && node tooling/generate-html-data.js && node node_modules/tooling/compile-to-definitions && node node_modules/tooling/precompile-schemas && node node_modules/tooling/generate-types --no-template-literals && node tooling/generate-internal-serializables.js",
+    "lint:special": "node node_modules/tooling/inherit-types && node tooling/generate-runtime-code.js && node tooling/generate-wasm-code.js && node tooling/generate-css-data.js && node tooling/generate-html-data.js && node node_modules/tooling/compile-to-definitions && node node_modules/tooling/precompile-schemas && node node_modules/tooling/generate-types --no-template-literals && node tooling/generate-internal-serializables.js",
     "lint:types": "tsc",
     "lint:types-test": "tsc -p tsconfig.types.test.json",
     "lint:types-benchmark": "tsc -p tsconfig.types.benchmark.json",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

`tooling`'s `lockfile-lint` checks that every `yarn.lock` entry resolves to `registry.yarnpkg.com` and carries a sha1/sha512 integrity hash. The upcoming npm migration retires `yarn.lock`, so the check is on its way out; dropping it now leaves `lint:special` one step shorter. Verified `yarn lint:special` still passes with its generators reporting up to date.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

build

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

n/a — no `lib/` behaviour changes; this removes a lint step.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a. `lockfile-lint` can be removed from `webpack/tooling` once no other consumer needs it.

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Claude Code was used to make the change and run `yarn lint:special` before committing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VMRMJTfRYkzN1N6GwmLbgp

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMRMJTfRYkzN1N6GwmLbgp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the special linting workflow; it no longer runs lockfile validation.
  - Other generation and validation commands remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->