### PR TITLE
fix: name chunk imports in the chunk loader

### DIFF
--- a/.changeset/006-analyzable-chunk-import-in-runtime.md
+++ b/.changeset/006-analyzable-chunk-import-in-runtime.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Name chunk imports in the chunk loader, not at each import site.

--- a/lib/APIPlugin.js
+++ b/lib/APIPlugin.js
@@ -42,6 +42,7 @@ const getConcatenatedModule = memoize(() =>
  */
 /** @import Compilation from "./Compilation" */
 /** @import ChunkGraph from "./ChunkGraph" */
+/** @import { RuntimeSpec } from "./util/runtime" */
 /** @import JavascriptParser, { Range } from "./javascript/JavascriptParser" */
 
 // Modules that reassign `__webpack_public_path__` at runtime, by compilation. A baked
@@ -79,17 +80,30 @@ const usesRuntimePublicPathOverride = (compilation) =>
 const overriddenRuntimes = new WeakMap();
 
 /**
- * Whether the public path is reassigned in any runtime `module` belongs to. Falls back
- * to the whole compilation when there is no chunk graph to place the module in.
+ * Whether the public path is reassigned in any runtime the reference belongs to,
+ * named either by the module emitting it or by `runtime` directly — a caller holding
+ * a chunk rather than a module has only the latter. Falls back to the whole
+ * compilation when neither can place it.
  * @param {Compilation} compilation compilation
  * @param {ChunkGraph=} chunkGraph the chunk graph
  * @param {Module=} module the module a reference is emitted into
- * @returns {boolean} true when a reassignment can reach this module's runtimes
+ * @param {RuntimeSpec=} runtime the runtime it is emitted for, where no module names it
+ * @returns {boolean} true when a reassignment can reach those runtimes
  */
-const runtimeUsesPublicPathOverride = (compilation, chunkGraph, module) => {
+const runtimeUsesPublicPathOverride = (
+	compilation,
+	chunkGraph,
+	module,
+	runtime
+) => {
 	const modules = runtimePublicPathOverride.get(compilation);
 	if (modules === undefined) return false;
-	if (chunkGraph === undefined || module === undefined) return true;
+	if (
+		chunkGraph === undefined ||
+		(module === undefined && runtime === undefined)
+	) {
+		return true;
+	}
 	// Keyed by the chunk graph, not the compilation: `executeModule` asks with a
 	// throw-away one whose answer must not outlive it.
 	let runtimes = overriddenRuntimes.get(chunkGraph);
@@ -115,8 +129,10 @@ const runtimeUsesPublicPathOverride = (compilation, chunkGraph, module) => {
 	if (overridden.size === 0) return false;
 	/** @type {Set<string>} */
 	const own = new Set();
-	for (const runtime of chunkGraph.getModuleRuntimes(module)) {
-		forEachRuntime(runtime, (key) => {
+	const reached =
+		module === undefined ? [runtime] : chunkGraph.getModuleRuntimes(module);
+	for (const each of reached) {
+		forEachRuntime(each, (key) => {
 			own.add(/** @type {string} */ (key));
 		});
 	}

--- a/lib/ContextModule.js
+++ b/lib/ContextModule.js
@@ -1215,60 +1215,11 @@ module.exports = webpackAsyncContext;`;
 		}
 		const shortMode = hasNoChunk && hasNoModuleDeferred && !hasFakeMap;
 		// Sorted before anything is keyed by request, so two items sharing one leave the
-		// same last writer in the map and in the loaders beside it.
+		// same last writer in the map.
 		const sortedItems = items.sort((a, b) => {
 			if (a.userRequest === b.userRequest) return 0;
 			return a.userRequest < b.userRequest ? -1 : 1;
 		});
-		let needEnsureChunk = !hasNoChunk;
-		/** @type {Map<string, string[]> | undefined} */
-		let loaders;
-		// Only module output can name a chunk in an `import()`, so nothing else pays for
-		// building the loaders just to throw them away.
-		if (!hasNoChunk && runtimeTemplate.isModule()) {
-			/** @type {Map<string, string[]>} */
-			const perRequest = new Map();
-			let hasAnalyzable = false;
-			let hasFallback = false;
-			/**
-			 * @param {Chunk} chunk one chunk a request needs
-			 * @returns {string} a thunk loading it, by literal name where the chunk has one
-			 */
-			const loaderFor = (chunk) => {
-				// `.ei` always imports, where `.e` skips a chunk already loaded — the same
-				// filter `blockPromise` applies before reaching for it.
-				const analyzable =
-					chunk.hasRuntime() || chunk.id === null
-						? null
-						: runtimeTemplate.analyzableChunkImport(
-								chunk,
-								"",
-								runtimeRequirements,
-								this,
-								chunkGraph
-							);
-				if (analyzable !== null) {
-					hasAnalyzable = true;
-					return runtimeTemplate.returningFunction(analyzable);
-				}
-				hasFallback = true;
-				return runtimeTemplate.returningFunction(
-					`${RuntimeGlobals.ensureChunk}(${JSON.stringify(chunk.id)})`
-				);
-			};
-			for (const item of sortedItems) {
-				perRequest.set(
-					item.userRequest,
-					/** @type {Chunk[]} */ (item.chunks).map(loaderFor)
-				);
-			}
-			// Nothing gained when no chunk can be spelled out, and the plain id map is
-			// smaller, so the loaders are only written when at least one names its chunk.
-			if (hasAnalyzable) {
-				loaders = perRequest;
-				needEnsureChunk = hasFallback;
-			}
-		}
 		/** @type {Record<string, ModuleId | (ModuleId | FakeMapType | ChunkId[] | (ModuleId[] | undefined))[]>} */
 		const map = Object.create(null);
 		for (const item of sortedItems) {
@@ -1302,16 +1253,11 @@ module.exports = webpackAsyncContext;`;
 		const asyncDepsPosition = hasNoChunk ? chunksPosition : chunksPosition + 1;
 		const requestPrefix = hasNoChunk
 			? "Promise.resolve()"
-			: loaders !== undefined
-				? hasMultipleOrNoChunks
-					? `Promise.all(ids[${chunksPosition}].map(${runtimeTemplate.returningFunction("load()", "load")}))`
-					: `ids[${chunksPosition}][0]()`
-				: hasMultipleOrNoChunks
-					? `Promise.all(ids[${chunksPosition}].map(${RuntimeGlobals.ensureChunk}))`
-					: `${RuntimeGlobals.ensureChunk}(ids[${chunksPosition}][0])`;
-		// Only the id map reads it; nothing loads a chunk when there is none to load, and
-		// a map of loaders spells out every one it could reach for.
-		if (needEnsureChunk) {
+			: hasMultipleOrNoChunks
+				? `Promise.all(ids[${chunksPosition}].map(${RuntimeGlobals.ensureChunk}))`
+				: `${RuntimeGlobals.ensureChunk}(ids[${chunksPosition}][0])`;
+		// Nothing loads a chunk when there is none to load.
+		if (!hasNoChunk) {
 			runtimeRequirements.add(RuntimeGlobals.ensureChunk);
 		}
 		const returnModuleObject = this.getReturnModuleObjectSource(
@@ -1355,26 +1301,7 @@ function webpackAsyncContext(req) {
 	return ${requestPrefix}.then(${runtimeTemplate.returningFunction(returnModuleObject)});
 }`;
 
-		// A loader is source, not data, so the map holding one is written out rather than
-		// serialized — one entry per line, keeping the request next to what loads it.
-		const mapSource =
-			loaders === undefined
-				? JSON.stringify(map, null, "\t")
-				: `{\n${Object.keys(map)
-						.map((request) => {
-							const slots =
-								/** @type {(ModuleId | FakeMapType | ChunkId[] | (ModuleId[] | undefined))[]} */
-								(map[request]).map((slot, index) =>
-									index === chunksPosition
-										? `[${/** @type {string[]} */ (loaders.get(request)).join(", ")}]`
-										: // An absent `asyncDeps` slot is `null` to `JSON.stringify`.
-											slot === undefined
-											? "null"
-											: JSON.stringify(slot)
-								);
-							return `\t${JSON.stringify(request)}: [${slots.join(", ")}]`;
-						})
-						.join(",\n")}\n}`;
+		const mapSource = JSON.stringify(map, null, "\t");
 
 		return `${cst} map = ${mapSource};
 ${webpackAsyncContext}

--- a/lib/ContextModule.js
+++ b/lib/ContextModule.js
@@ -1254,7 +1254,12 @@ module.exports = webpackAsyncContext;`;
 		const requestPrefix = hasNoChunk
 			? "Promise.resolve()"
 			: hasMultipleOrNoChunks
-				? `Promise.all(ids[${chunksPosition}].map(${RuntimeGlobals.ensureChunk}))`
+				? // Wrapped because `map` hands its callback an index too, which the loader
+					// would otherwise read as a fetch priority.
+					`Promise.all(ids[${chunksPosition}].map(${runtimeTemplate.returningFunction(
+						`${RuntimeGlobals.ensureChunk}(id)`,
+						"id"
+					)}))`
 				: `${RuntimeGlobals.ensureChunk}(ids[${chunksPosition}][0])`;
 		// Nothing loads a chunk when there is none to load.
 		if (!hasNoChunk) {

--- a/lib/RuntimeGlobals.js
+++ b/lib/RuntimeGlobals.js
@@ -16,13 +16,6 @@ module.exports.amdDefine = "__webpack_require__.amdD";
 module.exports.amdOptions = "__webpack_require__.amdO";
 
 /**
- * analyzable single-chunk `import()` that keeps `ensureChunk` timing and deduplication:
- * resolves immediately for an installed chunk, else runs the literal import and installs it
- * Signature: (chunkId, () => Promise) => Promise
- */
-module.exports.analyzableChunkImport = "__webpack_require__.ei";
-
-/**
  * Creates an async module. The body function must be a async function.
  * "module.exports" will be decorated with an AsyncModulePromise.
  * The body function will be called.

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -9,14 +9,7 @@ const { CachedSource, ReplaceSource } = require("webpack-sources");
 const APIPlugin = require("./APIPlugin");
 
 const InitFragment = require("./InitFragment");
-const {
-	ASSET_TYPE,
-	ASSET_URL_TYPE,
-	CSS_TYPE,
-	HTML_TYPE,
-	JAVASCRIPT_TYPE,
-	RUNTIME_TYPE
-} = require("./ModuleSourceTypeConstants");
+const { CSS_TYPE, JAVASCRIPT_TYPE } = require("./ModuleSourceTypeConstants");
 const { WEBASSEMBLY_MODULE_TYPE_ASYNC } = require("./ModuleTypeConstants");
 const RuntimeGlobals = require("./RuntimeGlobals");
 const Template = require("./Template");
@@ -174,17 +167,6 @@ const rootedParts = (parts) =>
 			]
 		: parts;
 
-// Types that ride the chunk itself or render their own asset, so no `.f` handler
-// fetches them; every other type may install one, so the map has to exist for it.
-/** @type {Set<string>} */
-const TYPES_WITHOUT_CHUNK_HANDLER = new Set([
-	JAVASCRIPT_TYPE,
-	RUNTIME_TYPE,
-	ASSET_TYPE,
-	ASSET_URL_TYPE,
-	HTML_TYPE
-]);
-
 /**
  * Where a literal is read from — the `../` path back to the output root, and whether
  * the chunk loader fetched the chunk it sits in through `output.publicPath`.
@@ -280,6 +262,10 @@ const ANALYZABLE_TOKEN_PREFIX = "./@@webpackAnalyzableChunk:";
 const ANALYZABLE_TOKEN_REGEXP = /\.\/@@webpackAnalyzableChunk:([\w-]+)@@/g;
 // The same token read back out of one quoted specifier.
 const ANALYZABLE_TOKEN_PAYLOAD = /@@webpackAnalyzableChunk:([\w-]+)@@/;
+
+// What `import()` resolves as a place rather than as a package name: relative,
+// rooted, or carrying a scheme. Matched against the quote the specifier opens with.
+const RESOLVABLE_SPECIFIER = /^"(?:\.{0,2}\/|[a-zA-Z][\w+.-]*:)/;
 
 // Stands in for the compilation hash inside an otherwise resolved filename, with the
 // requested length when the placeholder asked for one.
@@ -723,7 +709,8 @@ class RuntimeTemplate {
 			APIPlugin.runtimeUsesPublicPathOverride(
 				this.compilation,
 				scoped ? chunkGraph : undefined,
-				placedModule
+				placedModule,
+				runtime
 			)
 		) {
 			return this._analyzableBailout(
@@ -735,36 +722,12 @@ class RuntimeTemplate {
 
 		if (form === "import") {
 			// Read through a native `import()`, or it is not this feature at all.
-			if (outputOptions.chunkFormat !== "module") {
-				return this._analyzableBailout(
-					module,
-					`output.chunkFormat is ${JSON.stringify(outputOptions.chunkFormat)}, so chunks are not read through a native import()`,
-					false
-				);
+			const outputReason = this._chunkImportOutputReason();
+			if (outputReason !== null) {
+				return this._analyzableBailout(module, outputReason, false);
 			}
-			if (outputOptions.importFunctionName !== "import") {
-				return this._analyzableBailout(
-					module,
-					`output.importFunctionName is ${JSON.stringify(outputOptions.importFunctionName)}, so the call site is not a native import()`,
-					false
-				);
-			}
-			// A worker loading its own chunks some other way keeps that runtime; one on
-			// `import` uses the same ESM loader as the main graph, so it can be analyzable.
-			for (const originChunk of /** @type {ChunkGraph} */ (
-				chunkGraph
-			).getModuleChunksIterable(/** @type {Module} */ (placedModule))) {
-				const entryOptions = originChunk.getEntryOptions();
-				if (!entryOptions || !entryOptions.worker) continue;
-				// `WorkerAndWorkletPlugin` always seeds this from `output.workerChunkLoading`.
-				if (entryOptions.chunkLoading !== "import") {
-					return this._analyzableBailout(
-						module,
-						`this worker loads its chunks with ${JSON.stringify(entryOptions.chunkLoading)}, not "import"`,
-						false
-					);
-				}
-			}
+			// A worker loading its own chunks some other way needs no answer here: it gets
+			// a chunk loader of its own, and only the ESM one asks this.
 			return true;
 		}
 
@@ -2714,7 +2677,7 @@ class RuntimeTemplate {
 	 * @param {string} options.message the message
 	 * @param {ChunkGraph} options.chunkGraph the chunk graph
 	 * @param {RuntimeRequirements} options.runtimeRequirements if set, will be filled with runtime requirements
-	 * @param {Module=} options.originModule the module the `import()` is emitted into
+	 * @param {Module=} options.originModule the module the `import()` is emitted into, to report against
 	 * @returns {string} expression
 	 */
 	blockPromise({
@@ -2744,156 +2707,32 @@ class RuntimeTemplate {
 			message,
 			chunkName: block.chunkName
 		});
-		// `fetchPriority` is unsupported for ESM output (a native `import()` can't carry it,
-		// and the ESM chunk loader ignores the argument), so it never blocks the analyzable form.
-		// TODO recheck: browsers honor `fetchpriority` on `modulepreload` only when the
-		// preload scanner sees it, so a runtime-injected hint is inert; support it here if
-		// that changes.
+		// An output that cannot use a native `import()` gets no ESM chunk loader to ask,
+		// so the reason is recorded here, where any build generates its imports.
+		if (this.outputOptions.module && originModule !== undefined) {
+			const outputReason = this._chunkImportOutputReason();
+			if (outputReason !== null) {
+				this._analyzableBailout(originModule, outputReason, false);
+			}
+		}
 		const fetchPriority = chunkGroup.options.fetchPriority;
+		const priorityArg = fetchPriority
+			? `, ${JSON.stringify(fetchPriority)}`
+			: "";
+		if (chunks.length === 0) return `Promise.resolve(${comment.trim()})`;
+		runtimeRequirements.add(RuntimeGlobals.ensureChunk);
+		if (fetchPriority) {
+			runtimeRequirements.add(RuntimeGlobals.hasFetchPriority);
+		}
 		if (chunks.length === 1) {
-			const analyzable = this.analyzableChunkImport(
-				chunks[0],
-				comment,
-				runtimeRequirements,
-				originModule,
-				chunkGraph
-			);
-			if (analyzable !== null) {
-				return analyzable;
-			}
 			const chunkId = JSON.stringify(chunks[0].id);
-			runtimeRequirements.add(RuntimeGlobals.ensureChunk);
-
-			if (fetchPriority) {
-				runtimeRequirements.add(RuntimeGlobals.hasFetchPriority);
-			}
-
-			return `${RuntimeGlobals.ensureChunk}(${comment}${chunkId}${
-				fetchPriority ? `, ${JSON.stringify(fetchPriority)}` : ""
-			})`;
-		} else if (chunks.length > 0) {
-			let needEnsureChunk = false;
-			/**
-			 * Analyzable `import()` for a solely-owned JS chunk, else runtime ensureChunk.
-			 * @param {Chunk} chunk chunk
-			 * @returns {string} require chunk id code
-			 */
-			const requireChunkId = (chunk) => {
-				const analyzable = this.analyzableChunkImport(
-					chunk,
-					"",
-					runtimeRequirements,
-					originModule,
-					chunkGraph
-				);
-				if (analyzable !== null) return analyzable;
-				needEnsureChunk = true;
-				return `${RuntimeGlobals.ensureChunk}(${JSON.stringify(chunk.id)}${
-					fetchPriority ? `, ${JSON.stringify(fetchPriority)}` : ""
-				})`;
-			};
-			const items = chunks.map(requireChunkId);
-			if (needEnsureChunk) {
-				runtimeRequirements.add(RuntimeGlobals.ensureChunk);
-				// Only needed when an `ensureChunk(id, priority)` call is actually emitted.
-				if (fetchPriority) {
-					runtimeRequirements.add(RuntimeGlobals.hasFetchPriority);
-				}
-			}
-			return `Promise.all(${comment.trim()}[${items.join(", ")}])`;
+			return `${RuntimeGlobals.ensureChunk}(${comment}${chunkId}${priorityArg})`;
 		}
-		return `Promise.resolve(${comment.trim()})`;
-	}
-
-	/**
-	 * Whether any module of `chunk` carries a source type with a chunk handler of its
-	 * own, which `.ei` dispatches alongside the javascript one.
-	 * @param {Chunk} chunk the chunk being imported
-	 * @param {ChunkGraph} chunkGraph the chunk graph
-	 * @returns {boolean} true when a handler beyond the javascript one is reached
-	 */
-	_chunkLoadsBeyondJs(chunk, chunkGraph) {
-		for (const module of chunkGraph.getChunkModulesIterable(chunk)) {
-			for (const type of chunkGraph.getModuleSourceTypes(module)) {
-				if (!TYPES_WITHOUT_CHUNK_HANDLER.has(type)) return true;
-			}
-		}
-		return false;
-	}
-
-	/**
-	 * For ESM module output, load a single statically-named chunk through the
-	 * `analyzableChunkImport` helper — a literal `import("./chunk.js")` other bundlers
-	 * and webpack itself can follow, wrapped to keep `ensureChunk` timing and deduplication.
-	 * Returns `null` to fall back to the runtime `ensureChunk` form.
-	 * @param {Chunk} chunk the chunk to load
-	 * @param {string} comment leading comment (chunk name / message)
-	 * @param {RuntimeRequirements} runtimeRequirements runtime requirements
-	 * @param {Module | undefined} originModule the module the `import()` is emitted into
-	 * @param {ChunkGraph} chunkGraph the chunk graph
-	 * @returns {string | null} the import expression, or `null`
-	 */
-	analyzableChunkImport(
-		chunk,
-		comment,
-		runtimeRequirements,
-		originModule,
-		chunkGraph
-	) {
-		// `blockPromise` has already dropped any chunk without an id. Without an origin
-		// there is nothing the specifier could be relative to.
-		if (
-			!originModule ||
-			!this.supportsAnalyzable("import", chunkGraph, originModule)
-		) {
-			return null;
-		}
-		// `.ei` always performs the import, where `.e` only reaches the javascript
-		// loader when there is javascript to load. A module federation remote is the
-		// case that matters: its chunk is emitted by the container's build, not this one.
-		if (!JavascriptModulesPlugin.chunkHasJs(chunk, chunkGraph)) {
-			return this._analyzableBailout(
-				originModule,
-				"this compilation emits no javascript for the chunk, so there is nothing to import",
-				null
-			);
-		}
-		// Relative to the consuming chunk (`import.meta.url`) for `auto`, else an
-		// absolute publicPath prefix.
-		const specifier = this._getAnalyzableChunkSpecifier(
-			undefined,
-			chunk,
-			originModule,
-			chunkGraph
+		const items = chunks.map(
+			(chunk) =>
+				`${RuntimeGlobals.ensureChunk}(${JSON.stringify(chunk.id)}${priorityArg})`
 		);
-		if (specifier === null) {
-			return null;
-		}
-		// `import()` needs a resolvable specifier — relative (`./`, `../`), absolute (`/`)
-		// or a URL scheme. A bare one is a package name, so make it explicitly relative
-		// the way the chunk loader does. (`new URL(...)` callers accept bare vs their base.)
-		const resolvableSpecifier = /^"(?:\.{0,2}\/|[a-zA-Z][\w+.-]*:)/.test(
-			specifier
-		)
-			? specifier
-			: `"./${specifier.slice(1)}`;
-		runtimeRequirements.add(RuntimeGlobals.analyzableChunkImport);
-		// Prefetch/preload children and every non-javascript source type are loaded by a
-		// `.f` handler, which `.ei` dispatches — but they attach to `.f`, so it has to
-		// exist. The runtime `ensureChunk` around it does not.
-		if (
-			chunk.hasChildByOrder(chunkGraph, "prefetch", true) ||
-			chunk.hasChildByOrder(chunkGraph, "preload", true) ||
-			chunk.hasChildByOrder(chunkGraph, "cssPreload", true) ||
-			this._chunkLoadsBeyondJs(chunk, chunkGraph)
-		) {
-			runtimeRequirements.add(RuntimeGlobals.ensureChunkHandlers);
-		}
-		// Drop-in for `ensureChunk(id)`: the literal `import()` can be statically
-		// followed, the helper keeps webpack's install timing and deduplication.
-		return `${RuntimeGlobals.analyzableChunkImport}(${JSON.stringify(
-			chunk.id
-		)}, ${this.returningFunction(`import(${comment}${resolvableSpecifier})`)})`;
+		return `Promise.all(${comment.trim()}[${items.join(", ")}])`;
 	}
 
 	/**
@@ -3893,6 +3732,107 @@ class RuntimeTemplate {
 	}
 
 	/**
+	 * Why no chunk import of this build can be a native `import()`, read from the
+	 * output configuration alone, or `null` when nothing in it rules one out.
+	 * @returns {string | null} the reason
+	 */
+	_chunkImportOutputReason() {
+		const { chunkFormat, importFunctionName } = this.outputOptions;
+		if (chunkFormat !== "module") {
+			return `output.chunkFormat is ${JSON.stringify(chunkFormat)}, so chunks are not read through a native import()`;
+		}
+		if (importFunctionName !== "import") {
+			return `output.importFunctionName is ${JSON.stringify(importFunctionName)}, so the call site is not a native import()`;
+		}
+		return null;
+	}
+
+	/**
+	 * Records that this runtime reads its chunks some way other than a native
+	 * `import()`, so no literal can name what it loads. Recorded on the entries that
+	 * chose it, which is where the setting behind it lives.
+	 * @param {Chunk} chunk the runtime chunk
+	 * @param {ChunkGraph} chunkGraph the chunk graph
+	 * @returns {void}
+	 */
+	reportChunkImportBailout(chunk, chunkGraph) {
+		if (!this.outputOptions.module) return;
+		const entryOptions = chunk.getEntryOptions();
+		const chunkLoading =
+			entryOptions && entryOptions.chunkLoading !== undefined
+				? entryOptions.chunkLoading
+				: this.outputOptions.chunkLoading;
+		const subject = entryOptions && entryOptions.worker ? "worker" : "runtime";
+		const reason = `this ${subject} loads its chunks with ${JSON.stringify(chunkLoading)}, not "import"`;
+		for (const module of chunkGraph.getChunkEntryModulesIterable(chunk)) {
+			this._analyzableBailout(module, reason, false);
+		}
+	}
+
+	/**
+	 * A literal `import()` specifier for every javascript chunk a runtime loads on
+	 * demand, keyed by chunk id, or `null` when one of them cannot be named here. The
+	 * map is written into the runtime chunk rather than at each import site, so a
+	 * hashed chunk name reaches no module that imports it.
+	 * @param {Chunk} runtimeChunk the chunk holding the chunk loader
+	 * @param {ChunkGraph} chunkGraph the chunk graph
+	 * @param {ReadOnlyRuntimeRequirements} runtimeRequirements what that chunk needs
+	 * @param {Module=} consumingModule the runtime module, where one exists to report against
+	 * @returns {Map<ChunkId, string> | null} the specifiers, or `null` to keep the runtime form
+	 */
+	analyzableChunkImports(
+		runtimeChunk,
+		chunkGraph,
+		runtimeRequirements,
+		consumingModule
+	) {
+		// The runtime names the scope `__webpack_public_path__` belongs to, so the
+		// answer holds whether or not a runtime module is there to ask about.
+		if (
+			!this.supportsAnalyzable(
+				"import",
+				chunkGraph,
+				consumingModule,
+				runtimeChunk.runtime
+			)
+		) {
+			return null;
+		}
+		// An initial chunk is installed before the loader runs and a chunk carrying a
+		// runtime is reached by a static import, so neither is ever looked up here.
+		const installed = new Set(runtimeChunk.getAllInitialChunks());
+		/** @type {Chunk[]} */
+		const chunks = [];
+		for (const chunk of runtimeChunk.getAllReferencedChunks()) {
+			if (
+				chunk.hasRuntime() ||
+				installed.has(chunk) ||
+				!JavascriptModulesPlugin.chunkHasJs(chunk, chunkGraph)
+			) {
+				continue;
+			}
+			chunks.push(chunk);
+		}
+		const specifiers = this._analyzableChunkSpecifiers(
+			chunks,
+			chunkGraph,
+			consumingModule,
+			[runtimeChunk],
+			JAVASCRIPT_TYPE,
+			runtimeRequirements
+		);
+		if (specifiers === null) return null;
+		for (const [id, specifier] of specifiers) {
+			// A bare specifier is a package name, so spell it relative the way the
+			// runtime form's `.p + <file>` would have resolved it.
+			if (!RESOLVABLE_SPECIFIER.test(specifier)) {
+				specifiers.set(id, `"./${specifier.slice(1)}`);
+			}
+		}
+		return specifiers;
+	}
+
+	/**
 	 * The urls of one asset of each of `chunks`, written out so they can be read by
 	 * chunk id, or `null` as soon as one of them cannot be named here.
 	 * @param {Iterable<Chunk>} chunks the chunks whose asset is wanted
@@ -3914,13 +3854,48 @@ class RuntimeTemplate {
 		if (!this.supportsAnalyzable("url-runtime", chunkGraph, consumingModule)) {
 			return null;
 		}
+		const urls = this._analyzableChunkSpecifiers(
+			chunks,
+			chunkGraph,
+			consumingModule,
+			consumingChunks,
+			sourceType,
+			runtimeRequirements
+		);
+		if (urls === null) return null;
+		for (const [id, specifier] of urls) {
+			urls.set(id, `${this.importMetaUrl(specifier)}.href`);
+		}
+		return urls;
+	}
+
+	/**
+	 * The quoted specifier naming one asset of each of `chunks`, keyed by chunk id, or
+	 * `null` as soon as one of them cannot be named here. What the name is read against
+	 * is the caller's: a url resolves it, an `import()` hands it to the loader.
+	 * @param {Iterable<Chunk>} chunks the chunks whose asset is wanted
+	 * @param {ChunkGraph} chunkGraph the chunk graph
+	 * @param {Module | undefined} consumingModule the runtime module, where one exists to report against
+	 * @param {Chunk[]} consumingChunks the chunks the specifiers are written into
+	 * @param {string} sourceType which asset of each chunk to name
+	 * @param {ReadOnlyRuntimeRequirements} runtimeRequirements what the runtime chunk needs
+	 * @returns {Map<ChunkId, string> | null} the specifiers, or `null` to keep the runtime form
+	 */
+	_analyzableChunkSpecifiers(
+		chunks,
+		chunkGraph,
+		consumingModule,
+		consumingChunks,
+		sourceType,
+		runtimeRequirements
+	) {
 		// A hot update re-ships the runtime module only when its own code changes, so
-		// each url has to be text nothing but an id joining or leaving the map can move.
+		// each name has to be text nothing but an id joining or leaving the map can move.
 		const hot = runtimeRequirements.has(
 			RuntimeGlobals.hmrDownloadUpdateHandlers
 		);
 		/** @type {Map<ChunkId, string>} */
-		const urls = new Map();
+		const specifiers = new Map();
 		for (const chunk of chunks) {
 			if (chunk.id === null) continue;
 			const specifier = this._getAnalyzableChunkSpecifier(
@@ -3939,9 +3914,9 @@ class RuntimeTemplate {
 			) {
 				return this._analyzableBailout(consumingModule, HOT_NAME_BAILOUT, null);
 			}
-			urls.set(chunk.id, `${this.importMetaUrl(specifier)}.href`);
+			specifiers.set(chunk.id, specifier);
 		}
-		return urls.size > 0 ? urls : null;
+		return specifiers.size > 0 ? specifiers : null;
 	}
 
 	/**

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -3762,6 +3762,7 @@ class RuntimeTemplate {
 			entryOptions && entryOptions.chunkLoading !== undefined
 				? entryOptions.chunkLoading
 				: this.outputOptions.chunkLoading;
+		if (chunkLoading === "import") return;
 		const subject = entryOptions && entryOptions.worker ? "worker" : "runtime";
 		const reason = `this ${subject} loads its chunks with ${JSON.stringify(chunkLoading)}, not "import"`;
 		for (const module of chunkGraph.getChunkEntryModulesIterable(chunk)) {

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -3770,6 +3770,22 @@ class RuntimeTemplate {
 	}
 
 	/**
+	 * Whether the loader still needs to build a url from a chunk id: a chunk carrying
+	 * a runtime of its own is reached by a static import and so is never named in the
+	 * map, and only a runtime that can reach one has to keep the fallback.
+	 * @param {Chunk} runtimeChunk the chunk holding the chunk loader
+	 * @param {ChunkGraph} chunkGraph the chunk graph
+	 * @returns {boolean} true when an id the map does not hold can reach the loader
+	 */
+	chunkImportsNeedRuntimeUrl(runtimeChunk, chunkGraph) {
+		for (const chunk of runtimeChunk.getAllReferencedChunks()) {
+			if (chunk === runtimeChunk || !chunk.hasRuntime()) continue;
+			if (JavascriptModulesPlugin.chunkHasJs(chunk, chunkGraph)) return true;
+		}
+		return false;
+	}
+
+	/**
 	 * A literal `import()` specifier for every javascript chunk a runtime loads on
 	 * demand, keyed by chunk id, or `null` when one of them cannot be named here. The
 	 * map is written into the runtime chunk rather than at each import site, so a
@@ -3798,13 +3814,14 @@ class RuntimeTemplate {
 		) {
 			return null;
 		}
-		// An initial chunk is installed before the loader runs and a chunk carrying a
-		// runtime is reached by a static import, so neither is ever looked up here.
+		// An initial chunk and one carrying a runtime are both reached by a static
+		// import, so naming either here would only make two hashes chase each other.
 		const installed = new Set(runtimeChunk.getAllInitialChunks());
 		/** @type {Chunk[]} */
 		const chunks = [];
 		for (const chunk of runtimeChunk.getAllReferencedChunks()) {
 			if (
+				chunk === runtimeChunk ||
 				chunk.hasRuntime() ||
 				installed.has(chunk) ||
 				!JavascriptModulesPlugin.chunkHasJs(chunk, chunkGraph)

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -36,7 +36,11 @@ const { equals } = require("./util/ArrayHelpers");
 const { getScheme } = require("./util/URLAbsoluteSpecifier");
 const { compareIds } = require("./util/comparators");
 const compileBooleanMatcher = require("./util/compileBooleanMatcher");
-const { getUndoPath, toJsStringLiteral } = require("./util/identifier");
+const {
+	RESOLVABLE_SPECIFIER_REGEXP,
+	getUndoPath,
+	toJsStringLiteral
+} = require("./util/identifier");
 const memoize = require("./util/memoize");
 const { propertyAccess, propertyName } = require("./util/property");
 const {
@@ -262,10 +266,6 @@ const ANALYZABLE_TOKEN_PREFIX = "./@@webpackAnalyzableChunk:";
 const ANALYZABLE_TOKEN_REGEXP = /\.\/@@webpackAnalyzableChunk:([\w-]+)@@/g;
 // The same token read back out of one quoted specifier.
 const ANALYZABLE_TOKEN_PAYLOAD = /@@webpackAnalyzableChunk:([\w-]+)@@/;
-
-// What `import()` resolves as a place rather than as a package name: relative,
-// rooted, or carrying a scheme. Matched against the quote the specifier opens with.
-const RESOLVABLE_SPECIFIER = /^"(?:\.{0,2}\/|[a-zA-Z][\w+.-]*:)/;
 
 // Stands in for the compilation hash inside an otherwise resolved filename, with the
 // requested length when the placeholder asked for one.
@@ -3771,16 +3771,37 @@ class RuntimeTemplate {
 	}
 
 	/**
-	 * Whether the loader still needs to build a url from a chunk id: a chunk carrying
-	 * a runtime of its own is reached by a static import and so is never named in the
-	 * map, and only a runtime that can reach one has to keep the fallback.
+	 * The chunks this loader can be handed an id for: the ones held by a group outside
+	 * the initial wave, which is what an `import()` or a context map turns into an id.
+	 * @param {Chunk} runtimeChunk the chunk holding the chunk loader
+	 * @returns {Set<Chunk>} the chunks reachable from here through a non-initial group
+	 */
+	_loadableChunks(runtimeChunk) {
+		const queue = new Set(runtimeChunk.groupsIterable);
+		/** @type {Set<Chunk>} */
+		const chunks = new Set();
+		for (const group of queue) {
+			if (!group.isInitial()) {
+				for (const chunk of group.chunks) chunks.add(chunk);
+			}
+			for (const child of group.childrenIterable) queue.add(child);
+		}
+		return chunks;
+	}
+
+	/**
+	 * Whether the loader still needs to build a url from a chunk id, which is the case
+	 * for a chunk it can be asked for that `analyzableChunkImports` leaves unnamed: one
+	 * carrying a runtime of its own, or one a second entrypoint has at startup.
 	 * @param {Chunk} runtimeChunk the chunk holding the chunk loader
 	 * @param {ChunkGraph} chunkGraph the chunk graph
 	 * @returns {boolean} true when an id the map does not hold can reach the loader
 	 */
 	chunkImportsNeedRuntimeUrl(runtimeChunk, chunkGraph) {
-		for (const chunk of runtimeChunk.getAllReferencedChunks()) {
-			if (chunk === runtimeChunk || !chunk.hasRuntime()) continue;
+		const installed = new Set(runtimeChunk.getAllInitialChunks());
+		for (const chunk of this._loadableChunks(runtimeChunk)) {
+			if (chunk === runtimeChunk) continue;
+			if (!chunk.hasRuntime() && !installed.has(chunk)) continue;
 			if (JavascriptModulesPlugin.chunkHasJs(chunk, chunkGraph)) return true;
 		}
 		return false;
@@ -3843,7 +3864,7 @@ class RuntimeTemplate {
 		for (const [id, specifier] of specifiers) {
 			// A bare specifier is a package name, so spell it relative the way the
 			// runtime form's `.p + <file>` would have resolved it.
-			if (!RESOLVABLE_SPECIFIER.test(specifier)) {
+			if (!RESOLVABLE_SPECIFIER_REGEXP.test(specifier.slice(1))) {
 				specifiers.set(id, `"./${specifier.slice(1)}`);
 			}
 		}
@@ -4396,7 +4417,7 @@ class RuntimeTemplate {
 						// the chunk loader does. A literal part may still carry a stand-in of its own,
 						// so finish those here rather than scanning again.
 						return fillFullHash(
-							/^(?:\.{0,2}\/|[a-zA-Z][\w+.-]*:)/.test(specifier)
+							RESOLVABLE_SPECIFIER_REGEXP.test(specifier)
 								? specifier
 								: `./${specifier}`
 						);

--- a/lib/esm/ModuleChunkLoadingPlugin.js
+++ b/lib/esm/ModuleChunkLoadingPlugin.js
@@ -78,7 +78,6 @@ class ModuleChunkLoadingPlugin {
 				RuntimeGlobals.ensureChunkHandlers,
 				RuntimeGlobals.baseURI,
 				RuntimeGlobals.externalInstallChunk,
-				RuntimeGlobals.analyzableChunkImport,
 				RuntimeGlobals.onChunksLoaded,
 				RuntimeGlobals.hmrDownloadUpdateHandlers,
 				RuntimeGlobals.hmrDownloadManifest
@@ -90,7 +89,6 @@ class ModuleChunkLoadingPlugin {
 			for (const requirement of [
 				RuntimeGlobals.ensureChunkHandlers,
 				RuntimeGlobals.externalInstallChunk,
-				RuntimeGlobals.analyzableChunkImport,
 				RuntimeGlobals.hmrDownloadUpdateHandlers
 			]) {
 				compilation.hooks.runtimeRequirementInTree
@@ -135,11 +133,28 @@ class ModuleChunkLoadingPlugin {
 			}
 
 			// Keyed on `ensureChunk`, not on the handler map: only the runtime chunk loader
-			// builds a URL from a chunk id, and an analyzable `import()` carries its own.
+			// builds a URL from a chunk id, and a baked specifier carries its own.
 			compilation.hooks.runtimeRequirementInTree
 				.for(RuntimeGlobals.ensureChunk)
-				.tap(PLUGIN_NAME, (chunk, set) => {
-					if (!isEnabledForChunk(chunk)) return;
+				.tap(PLUGIN_NAME, (chunk, set, { chunkGraph }) => {
+					if (!isEnabledForChunk(chunk)) {
+						compilation.runtimeTemplate.reportChunkImportBailout(
+							chunk,
+							chunkGraph
+						);
+						return;
+					}
+					// Asked as the runtime module asks, so the two always agree on whether
+					// a chunk id is ever turned into a url here.
+					if (
+						compilation.runtimeTemplate.analyzableChunkImports(
+							chunk,
+							chunkGraph,
+							set
+						) !== null
+					) {
+						return;
+					}
 
 					if (compilation.outputOptions.publicPath !== "auto") {
 						set.add(RuntimeGlobals.publicPath);

--- a/lib/esm/ModuleChunkLoadingPlugin.js
+++ b/lib/esm/ModuleChunkLoadingPlugin.js
@@ -144,14 +144,15 @@ class ModuleChunkLoadingPlugin {
 						);
 						return;
 					}
+
 					// Asked as the runtime module asks, so the two always agree on whether
 					// a chunk id is ever turned into a url here.
+					const { runtimeTemplate } = compilation;
 					if (
-						compilation.runtimeTemplate.analyzableChunkImports(
-							chunk,
-							chunkGraph,
-							set
-						) !== null
+						runtimeTemplate.analyzableChunkImports(chunk, chunkGraph, set) !==
+							null &&
+						!set.has(RuntimeGlobals.hmrDownloadUpdateHandlers) &&
+						!runtimeTemplate.chunkImportsNeedRuntimeUrl(chunk, chunkGraph)
 					) {
 						return;
 					}

--- a/lib/esm/ModuleChunkLoadingRuntimeModule.js
+++ b/lib/esm/ModuleChunkLoadingRuntimeModule.js
@@ -96,9 +96,6 @@ class ModuleChunkLoadingRuntimeModule extends RuntimeModule {
 		const withExternalInstallChunk = this._runtimeRequirements.has(
 			RuntimeGlobals.externalInstallChunk
 		);
-		const withAnalyzableImport = this._runtimeRequirements.has(
-			RuntimeGlobals.analyzableChunkImport
-		);
 		const withLoading = this._runtimeRequirements.has(
 			RuntimeGlobals.ensureChunkHandlers
 		);
@@ -111,8 +108,8 @@ class ModuleChunkLoadingRuntimeModule extends RuntimeModule {
 		const withHmrManifest = this._runtimeRequirements.has(
 			RuntimeGlobals.hmrDownloadManifest
 		);
-		// `.f.j` serves `ensureChunk`: an analyzable import dispatches every handler but
-		// this one. HMR's force-load knows only a chunk id, so it needs the loader too.
+		// `.f.j` serves `ensureChunk`. HMR's force-load knows only a chunk id, so it
+		// needs the loader too.
 		const withJsLoading =
 			withLoading &&
 			(this._runtimeRequirements.has(RuntimeGlobals.ensureChunk) || withHmr);
@@ -138,6 +135,16 @@ class ModuleChunkLoadingRuntimeModule extends RuntimeModule {
 						this
 					)
 				: null;
+		// Under module output every chunk the loader reaches is a known file, so it
+		// imports a literal specifier read by id instead of a url built from that id.
+		const chunkImports = withJsLoading
+			? runtimeTemplate.analyzableChunkImports(
+					chunk,
+					chunkGraph,
+					this._runtimeRequirements,
+					this
+				)
+			: null;
 		const conditionMap = chunkGraph.getChunkConditionMap(chunk, chunkHasJs);
 		const hasJsMatcher = compileBooleanMatcher(conditionMap);
 		const initialChunkIds = getInitialChunkIds(chunk, chunkGraph, chunkHasJs);
@@ -173,7 +180,6 @@ class ModuleChunkLoadingRuntimeModule extends RuntimeModule {
 		const withInstalledChunks =
 			withLoading ||
 			withExternalInstallChunk ||
-			withAnalyzableImport ||
 			withOnChunkLoad ||
 			withHmr ||
 			withPrefetch ||
@@ -188,6 +194,15 @@ class ModuleChunkLoadingRuntimeModule extends RuntimeModule {
 			chunkUrls === null
 				? `${RuntimeGlobals.publicPath} + ${RuntimeGlobals.getChunkScriptFilename}(${id})`
 				: `chunkUrls[${id}]()`;
+		const runtimeImport = `${importFunctionName}(${chunkImportBase} + ${RuntimeGlobals.getChunkScriptFilename}(chunkId))`;
+		// A hot update can force-load a chunk id this build never saw, which no baked
+		// map holds; `getChunkScriptFilename` is asked for alongside the hot handlers.
+		const chunkImport =
+			chunkImports === null
+				? runtimeImport
+				: withHmr
+					? `(${RuntimeGlobals.hasOwnProperty}(chunkImports, chunkId) ? chunkImports[chunkId]() : ${runtimeImport})`
+					: "chunkImports[chunkId]()";
 		return Template.asString([
 			withBaseURI
 				? this._generateBaseUri(chunk, rootOutputDir)
@@ -200,6 +215,20 @@ class ModuleChunkLoadingRuntimeModule extends RuntimeModule {
 								chunkUrls,
 								([id, url]) =>
 									`${JSON.stringify(String(id))}: ${runtimeTemplate.returningFunction(url)}`
+							).join(",\n")
+						)}\n};`,
+						""
+					]
+				: []),
+			...(chunkImports
+				? [
+						`${cst} chunkImports = {\n${Template.indent(
+							Array.from(
+								chunkImports,
+								([id, specifier]) =>
+									`${JSON.stringify(String(id))}: ${runtimeTemplate.returningFunction(
+										`${importFunctionName}(${specifier})`
+									)}`
 							).join(",\n")
 						)}\n};`,
 						""
@@ -221,7 +250,7 @@ class ModuleChunkLoadingRuntimeModule extends RuntimeModule {
 					])
 				: "// no installed chunks",
 			"",
-			withLoading || withExternalInstallChunk || withAnalyzableImport
+			withLoading || withExternalInstallChunk
 				? `${cst} installChunk = ${runtimeTemplate.basicFunction("data", [
 						runtimeTemplate.destructureObject(
 							[
@@ -280,9 +309,7 @@ class ModuleChunkLoadingRuntimeModule extends RuntimeModule {
 													: `if(${hasJsMatcher("chunkId")}) {`,
 												Template.indent([
 													"// setup Promise in chunk cache",
-													`${lt} promise = ${importFunctionName}(${chunkImportBase} + ${
-														RuntimeGlobals.getChunkScriptFilename
-													}(chunkId)).then(installChunk, ${runtimeTemplate.basicFunction(
+													`${lt} promise = ${chunkImport}.then(installChunk, ${runtimeTemplate.basicFunction(
 														"e",
 														[
 															"if(installedChunks[chunkId] !== 0) installedChunks[chunkId] = undefined;",
@@ -421,48 +448,6 @@ class ModuleChunkLoadingRuntimeModule extends RuntimeModule {
 						`${RuntimeGlobals.externalInstallChunk} = installChunk;`
 					])
 				: "// no external install chunk",
-			"",
-			withAnalyzableImport
-				? `${
-						RuntimeGlobals.analyzableChunkImport
-					} = ${runtimeTemplate.basicFunction("chunkId, importFn", [
-						// `ensureChunk` with its `.j` half replaced by a literal `import()` a foreign
-						// bundler can follow. The remaining handlers still run, so a chunk's css and
-						// its prefetch/preload children are not lost by taking this path.
-						`${lt} promises = [];`,
-						`${lt} installedChunkData = ${RuntimeGlobals.hasOwnProperty}(installedChunks, chunkId) ? installedChunks[chunkId] : undefined;`,
-						'if(installedChunkData !== 0) { // 0 means "already installed".',
-						Template.indent([
-							'// a Promise means "currently loading".',
-							"if(installedChunkData) {",
-							Template.indent(["promises.push(installedChunkData[1]);"]),
-							"} else {",
-							Template.indent([
-								`${lt} promise = importFn().then(installChunk, ${runtimeTemplate.basicFunction(
-									"e",
-									[
-										"if(installedChunks[chunkId] !== 0) installedChunks[chunkId] = undefined;",
-										"throw e;"
-									]
-								)});`,
-								`promise = Promise.race([promise, new Promise(${runtimeTemplate.expressionFunction(
-									"installedChunkData = installedChunks[chunkId] = [resolve]",
-									"resolve"
-								)})]);`,
-								"promises.push((installedChunkData[1] = promise));"
-							]),
-							"}"
-						]),
-						"}",
-						withLoading
-							? `Object.keys(${fn}).forEach(${runtimeTemplate.basicFunction(
-									"key",
-									[`if(key !== "j") ${fn}[key](chunkId, promises);`]
-								)});`
-							: "// no other chunk loading handlers",
-						"return Promise.all(promises);"
-					])};`
-				: "// no analyzable chunk import",
 			"",
 			withOnChunkLoad
 				? `${

--- a/lib/esm/ModuleChunkLoadingRuntimeModule.js
+++ b/lib/esm/ModuleChunkLoadingRuntimeModule.js
@@ -17,6 +17,7 @@ const { getInitialChunkIds } = require("../javascript/StartupHelpers");
 const { renderBaseUri } = require("../runtime/baseUri");
 const compileBooleanMatcher = require("../util/compileBooleanMatcher");
 const createHooksRegistry = require("../util/createHooksRegistry");
+const { RESOLVABLE_SPECIFIER_REGEXP } = require("../util/identifier");
 const memoize = require("../util/memoize");
 
 const getAPIPlugin = memoize(() => require("../APIPlugin"));
@@ -159,7 +160,7 @@ class ModuleChunkLoadingRuntimeModule extends RuntimeModule {
 			publicPath === "auto"
 				? JSON.stringify(rootOutputDir)
 				: typeof publicPath === "string" &&
-					  !/^(?:\.{0,2}\/|[a-zA-Z][\w+.-]*:)/.test(publicPath) &&
+					  !RESOLVABLE_SPECIFIER_REGEXP.test(publicPath) &&
 					  !getAPIPlugin().usesRuntimePublicPathOverride(compilation)
 					? `"./" + ${RuntimeGlobals.publicPath}`
 					: RuntimeGlobals.publicPath;

--- a/lib/esm/ModuleChunkLoadingRuntimeModule.js
+++ b/lib/esm/ModuleChunkLoadingRuntimeModule.js
@@ -195,12 +195,16 @@ class ModuleChunkLoadingRuntimeModule extends RuntimeModule {
 				? `${RuntimeGlobals.publicPath} + ${RuntimeGlobals.getChunkScriptFilename}(${id})`
 				: `chunkUrls[${id}]()`;
 		const runtimeImport = `${importFunctionName}(${chunkImportBase} + ${RuntimeGlobals.getChunkScriptFilename}(chunkId))`;
-		// A hot update can force-load a chunk id this build never saw, which no baked
-		// map holds; `getChunkScriptFilename` is asked for alongside the hot handlers.
+		// A hot update can force-load an id this build never saw, and a chunk with a
+		// runtime of its own is never named, so only those keep the url form.
+		const withRuntimeUrl =
+			chunkImports === null ||
+			withHmr ||
+			runtimeTemplate.chunkImportsNeedRuntimeUrl(chunk, chunkGraph);
 		const chunkImport =
 			chunkImports === null
 				? runtimeImport
-				: withHmr
+				: withRuntimeUrl
 					? `(${RuntimeGlobals.hasOwnProperty}(chunkImports, chunkId) ? chunkImports[chunkId]() : ${runtimeImport})`
 					: "chunkImports[chunkId]()";
 		return Template.asString([

--- a/lib/runtime/EnsureChunkRuntimeModule.js
+++ b/lib/runtime/EnsureChunkRuntimeModule.js
@@ -38,8 +38,8 @@ class EnsureChunkRuntimeModule extends RuntimeModule {
 	generate() {
 		const compilation = /** @type {Compilation} */ (this.compilation);
 		const { runtimeTemplate } = compilation;
-		// An analyzable `import()` dispatches the handlers itself, so a build can need the
-		// map without the function around it.
+		// HMR force-loads through the handler map by bare chunk id, so a build can need
+		// the map without the function around it.
 		const withEnsureChunk = this.runtimeRequirements.has(
 			RuntimeGlobals.ensureChunk
 		);

--- a/lib/util/identifier.js
+++ b/lib/util/identifier.js
@@ -18,6 +18,9 @@ const WINDOWS_PATH_SEPARATOR_REGEXP = /\\/g;
 const NODE_MODULES_REGEXP = /[\\/]node_modules[\\/]/i;
 // A file URL, the form `import.meta.resolve()` returns a local module in.
 const FILE_URL_REGEXP = /^file:\/\//i;
+// What `import()` resolves as a place rather than as a package name: relative,
+// rooted, or carrying a scheme.
+const RESOLVABLE_SPECIFIER_REGEXP = /^(?:\.{0,2}\/|[a-zA-Z][\w+.-]*:)/;
 
 /**
  * Converts a file URL to the path it names. Any other value is returned
@@ -582,6 +585,7 @@ const toJsStringLiteral = (str) =>
 
 module.exports.ABSOLUTE_PATH_REGEXP = ABSOLUTE_PATH_REGEXP;
 module.exports.NODE_MODULES_REGEXP = NODE_MODULES_REGEXP;
+module.exports.RESOLVABLE_SPECIFIER_REGEXP = RESOLVABLE_SPECIFIER_REGEXP;
 module.exports.WINDOWS_ABS_PATH_REGEXP = WINDOWS_ABS_PATH_REGEXP;
 module.exports.WINDOWS_PATH_SEPARATOR_REGEXP = WINDOWS_PATH_SEPARATOR_REGEXP;
 module.exports.absolutify = absolutify;

--- a/test/RuntimeTemplate.unittest.js
+++ b/test/RuntimeTemplate.unittest.js
@@ -332,6 +332,16 @@ describe("RuntimeTemplate.supportsAnalyzable", () => {
 		getEntryOptions: () => ({ worker: true, chunkLoading })
 	});
 
+	/**
+	 * @returns {ChunkGraph} a chunk graph whose chunk carries one entry module
+	 */
+	const entryChunkGraph = () =>
+		/** @type {ChunkGraph} */ (
+			/** @type {unknown} */ ({
+				getChunkEntryModulesIterable: () => [module]
+			})
+		);
+
 	it("should refuse every form unless the build emits ESM", () => {
 		const template = create({ output: { module: false } });
 		const { chunkGraph } = countingChunkGraph();
@@ -386,42 +396,50 @@ describe("RuntimeTemplate.supportsAnalyzable", () => {
 		}).toEqual({ array: false, renamed: false, both: true });
 	});
 
-	// A worker on its own chunk loader keeps that runtime; one on `import` shares the
-	// ESM loader with the main graph, so the literal reaches the same chunk.
-	it("should follow a worker entry's own chunk loading", () => {
-		const cases = {
-			importWorker: workerChunk("import"),
-			jsonpWorker: workerChunk("jsonp"),
-			nodeWorker: workerChunk("async-node")
-		};
-		/** @type {Record<string, boolean>} */
-		const answers = {};
-		for (const [name, chunk] of Object.entries(cases)) {
-			const { chunkGraph } = countingChunkGraph([chunk]);
-			answers[name] = create({}).supportsAnalyzable(
-				"import",
-				chunkGraph,
-				module
+	// A worker on its own chunk loader gets no ESM loader to name its chunks, so the
+	// reason is recorded against the entry that chose it rather than asked per module.
+	it("should report a worker entry's own chunk loading", () => {
+		/** @type {Record<string, string[]>} */
+		const reported = {};
+		for (const [name, chunkLoading] of [
+			["importWorker", "import"],
+			["jsonpWorker", "jsonp"],
+			["nodeWorker", "async-node"]
+		]) {
+			/** @type {string[]} */
+			const bailouts = [];
+			create({ bailouts }).reportChunkImportBailout(
+				/** @type {EXPECTED_ANY} */ (workerChunk(chunkLoading)),
+				entryChunkGraph()
 			);
+			reported[name] = bailouts;
 		}
 
-		expect(answers).toEqual({
-			importWorker: true,
-			jsonpWorker: false,
-			nodeWorker: false
+		expect(reported).toEqual({
+			importWorker: [],
+			jsonpWorker: [
+				'Analyzable ESM bailout: this worker loads its chunks with "jsonp", not "import"'
+			],
+			nodeWorker: [
+				'Analyzable ESM bailout: this worker loads its chunks with "async-node", not "import"'
+			]
 		});
 	});
 
-	// A non-worker entry carries `chunkLoading` too, and it is not the worker's.
-	it("should ignore chunk loading on an entry that is not a worker", () => {
-		const { chunkGraph } = countingChunkGraph([
-			{ getEntryOptions: () => ({ chunkLoading: "jsonp" }) },
-			{ getEntryOptions: () => undefined }
-		]);
-
-		expect(create({}).supportsAnalyzable("import", chunkGraph, module)).toBe(
-			true
+	// A non-worker entry carries `chunkLoading` too, and the reason names it as such.
+	it("should report an entry that is not a worker as a runtime", () => {
+		/** @type {string[]} */
+		const bailouts = [];
+		create({ bailouts }).reportChunkImportBailout(
+			/** @type {EXPECTED_ANY} */ ({
+				getEntryOptions: () => ({ chunkLoading: "jsonp" })
+			}),
+			entryChunkGraph()
 		);
+
+		expect(bailouts).toEqual([
+			'Analyzable ESM bailout: this runtime loads its chunks with "jsonp", not "import"'
+		]);
 	});
 
 	// `eval` devtool wraps each module in `eval(...)`, where `import.meta` is a syntax
@@ -469,11 +487,11 @@ describe("RuntimeTemplate.supportsAnalyzable", () => {
 	// unit-testable — the decision short-circuits before reading it unless a real
 	// build registered a `__webpack_public_path__` reassignment — so the case that
 	// pins it is configCases/wasm/analyzable-runtime-scope.
-	it("should walk the origin module's chunks once for an import", () => {
+	it("should read no chunk of the origin module for an import", () => {
 		const { chunkGraph, reads } = countingChunkGraph();
 		create({}).supportsAnalyzable("import", chunkGraph, module);
 
-		expect(reads()).toBe(1);
+		expect(reads()).toBe(0);
 	});
 
 	// `stats.optimizationBailout` is the channel this reports through, and one module

--- a/test/configCases/analyzable/block-origin-modules/index.js
+++ b/test/configCases/analyzable/block-origin-modules/index.js
@@ -42,6 +42,8 @@ it("should bake the import even though the block names no module of its own", ()
 	const region = bundle.slice(start, bundle.indexOf("};", start));
 
 	// One per emitter: `require.ensure`, AMD `require([...])` and the lazy-once context.
-	expect(region.split("import(")).toHaveLength(4);
+	for (const name of ["ensured", "amd_js", "ctx"]) {
+		expect([name, region.includes(name)]).toEqual([name, true]);
+	}
 	expect(bundle).toContain(`${"__webpack_require__"}.e(`);
 });

--- a/test/configCases/analyzable/block-origin-modules/index.js
+++ b/test/configCases/analyzable/block-origin-modules/index.js
@@ -35,10 +35,13 @@ it("should bake the import even though the block names no module of its own", ()
 		path.join(__STATS__.outputPath, "bundle0.mjs"),
 		"utf8"
 	);
-	const analyzableImport = `${"__webpack_require__"}.ei(`;
-	const ensureChunkCall = `${"__webpack_require__"}.e(`;
+	const importMap = `${"chunkImports"} = {`;
+	const start = bundle.indexOf(importMap);
+
+	expect(start).not.toBe(-1);
+	const region = bundle.slice(start, bundle.indexOf("};", start));
 
 	// One per emitter: `require.ensure`, AMD `require([...])` and the lazy-once context.
-	expect(bundle.split(analyzableImport)).toHaveLength(4);
-	expect(bundle).not.toContain(ensureChunkCall);
+	expect(region.split("import(")).toHaveLength(4);
+	expect(bundle).toContain(`${"__webpack_require__"}.e(`);
 });

--- a/test/configCases/analyzable/chunk-import-shared-initial-chunk/index.js
+++ b/test/configCases/analyzable/chunk-import-shared-initial-chunk/index.js
@@ -1,0 +1,20 @@
+import fs from "fs";
+import path from "path";
+
+it("should load a chunk a second entrypoint already has at startup", async () => {
+	const shared = await import("./shared.js");
+	expect(shared.load()).toBe("shared");
+	const lazy = await import("./lazy.js");
+	expect(lazy.default).toBe("lazy");
+});
+
+it("should keep the url fallback next to the names it can bake", () => {
+	const source = fs.readFileSync(
+		path.join(__STATS__.outputPath, "runtime.mjs"),
+		"utf8"
+	);
+
+	// Built at runtime so the needles are not source string literals here.
+	expect(source).toContain(`${"chunkImports"} = {`);
+	expect(source).toContain(`${"__webpack_require__"}.u(chunkId)`);
+});

--- a/test/configCases/analyzable/chunk-import-shared-initial-chunk/lazy.js
+++ b/test/configCases/analyzable/chunk-import-shared-initial-chunk/lazy.js
@@ -1,0 +1,1 @@
+export default "lazy";

--- a/test/configCases/analyzable/chunk-import-shared-initial-chunk/other.js
+++ b/test/configCases/analyzable/chunk-import-shared-initial-chunk/other.js
@@ -1,0 +1,3 @@
+import { load } from "./shared.js";
+
+export default load();

--- a/test/configCases/analyzable/chunk-import-shared-initial-chunk/shared.js
+++ b/test/configCases/analyzable/chunk-import-shared-initial-chunk/shared.js
@@ -1,0 +1,3 @@
+export function load() {
+	return "shared";
+}

--- a/test/configCases/analyzable/chunk-import-shared-initial-chunk/test.config.js
+++ b/test/configCases/analyzable/chunk-import-shared-initial-chunk/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return "./bundle0.mjs";
+	}
+};

--- a/test/configCases/analyzable/chunk-import-shared-initial-chunk/webpack.config.js
+++ b/test/configCases/analyzable/chunk-import-shared-initial-chunk/webpack.config.js
@@ -1,0 +1,35 @@
+"use strict";
+
+// `runtimeChunk` puts one loader in front of both entrypoints, so the chunk `splitChunks`
+// lifts out is one the first entry has at startup and the second asks the loader for.
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "node",
+	mode: "development",
+	devtool: false,
+	entry: {
+		bundle0: "./index.js",
+		other: "./other.js"
+	},
+	output: {
+		module: true,
+		filename: "[name].mjs",
+		chunkFilename: "[name].mjs",
+		publicPath: "auto"
+	},
+	optimization: {
+		chunkIds: "named",
+		runtimeChunk: "single",
+		splitChunks: {
+			cacheGroups: {
+				shared: {
+					test: /shared\.js/,
+					name: "shared",
+					chunks: "all",
+					enforce: true
+				}
+			}
+		}
+	}
+};

--- a/test/configCases/analyzable/chunkhash-name-follows-fill/index.js
+++ b/test/configCases/analyzable/chunkhash-name-follows-fill/index.js
@@ -15,7 +15,7 @@ it("should bake the name into a chunk its own content names", async () => {
 
 	// Nothing repairs `[chunkhash]` after a fill, so the literal is only sound because
 	// the fold put it into this chunk's hash first.
-	expect(source).toContain(`${"__webpack_require__"}.ei(`);
+	expect(source).toContain(`${"chunkImports"} = {`);
 	expect(source).toContain(`"./${lazy}"`);
 	expect(source).not.toContain(`${"__webpack_require__"}.u(`);
 });

--- a/test/configCases/analyzable/chunkhash-name-follows-fill/index.js
+++ b/test/configCases/analyzable/chunkhash-name-follows-fill/index.js
@@ -15,7 +15,13 @@ it("should bake the name into a chunk its own content names", async () => {
 
 	// Nothing repairs `[chunkhash]` after a fill, so the literal is only sound because
 	// the fold put it into this chunk's hash first.
-	expect(source).toContain(`${"chunkImports"} = {`);
-	expect(source).toContain(`"./${lazy}"`);
+	const importMap = `${"chunkImports"} = {`;
+	const start = source.indexOf(importMap);
+
+	expect(start).not.toBe(-1);
+	// Read inside the map, so the name cannot be matched from anywhere else in the chunk.
+	const region = source.slice(start, source.indexOf("};", start));
+
+	expect(region).toContain(`"./${lazy}"`);
 	expect(source).not.toContain(`${"__webpack_require__"}.u(`);
 });

--- a/test/configCases/analyzable/circular-chunk-hashes-repaired/index.js
+++ b/test/configCases/analyzable/circular-chunk-hashes-repaired/index.js
@@ -1,6 +1,8 @@
 import fs from "fs";
 import path from "path";
 
+const CHUNK_REFERENCE = /"\.\/[^"]+\.mjs"/g;
+
 it("should build rather than deadlock on two chunks that name each other", async () => {
 	const [a, b, c] = await Promise.all([
 		import("./a.js"),
@@ -12,24 +14,28 @@ it("should build rather than deadlock on two chunks that name each other", async
 	expect(c.default).toBe(3);
 });
 
-it("should bake both directions of the cycle under repaired names", () => {
+it("should name a mutually importing pair from one place", () => {
 	const dir = __STATS__.outputPath;
 	const names = fs.readdirSync(dir).filter((n) => n.endsWith(".mjs"));
 	const emitted = (prefix) =>
 		/** @type {string} */ (names.find((n) => n.startsWith(prefix)));
 	const read = (prefix) =>
 		fs.readFileSync(path.join(dir, emitted(prefix)), "utf8");
-	const helper = `${"__webpack_require__"}.ei`;
 
-	// Both bake, and the repair re-hashes the pair as one group: each spells exactly
-	// the name the other was emitted under.
-	expect(read("a_js")).toContain(`${helper}(`);
-	expect(read("a_js")).toContain(`"./${emitted("b_js")}"`);
-	expect(read("b_js")).toContain(`${helper}(`);
-	expect(read("b_js")).toContain(`"./${emitted("a_js")}"`);
+	// Neither names the other, so with `realContentHash` off there is still no pair
+	// of names chasing each other to re-hash as one group.
+	expect(read("a_js").match(CHUNK_REFERENCE)).toBe(null);
+	expect(read("b_js").match(CHUNK_REFERENCE)).toBe(null);
+
+	const bundle = read("bundle0");
+
+	expect(bundle).toContain(`${"chunkImports"} = {`);
+	for (const prefix of ["a_js", "b_js", "c_js"]) {
+		expect(bundle).toContain(`"./${emitted(prefix)}"`);
+	}
 });
 
-it("should rename only what the repair touched", () => {
+it("should need no repair at all", () => {
 	const dir = __STATS__.outputPath;
 	const before = JSON.parse(
 		Buffer.from(
@@ -40,9 +46,9 @@ it("should rename only what the repair touched", () => {
 	const after = fs.readdirSync(dir);
 	const find = (list, prefix) => list.find((n) => n.startsWith(prefix));
 
-	// The pair's names went stale with the fill, so both moved.
-	expect(find(after, "a_js")).not.toBe(find(before, "a_js"));
-	expect(find(after, "b_js")).not.toBe(find(before, "b_js"));
-	// Nothing the fill touched reaches this one, so it keeps the name it was given.
-	expect(find(after, "c_js")).toBe(find(before, "c_js"));
+	// The fill only ever lands in the chunk holding the loader, whose own name reads
+	// no hash — so no name goes stale and nothing has to be renamed after it.
+	for (const prefix of ["a_js", "b_js", "c_js"]) {
+		expect(find(after, prefix)).toBe(find(before, prefix));
+	}
 });

--- a/test/configCases/analyzable/circular-chunk-hashes-repaired/index.js
+++ b/test/configCases/analyzable/circular-chunk-hashes-repaired/index.js
@@ -28,10 +28,14 @@ it("should name a mutually importing pair from one place", () => {
 	expect(read("b_js").match(CHUNK_REFERENCE)).toBe(null);
 
 	const bundle = read("bundle0");
+	const start = bundle.indexOf(`${"chunkImports"} = {`);
 
-	expect(bundle).toContain(`${"chunkImports"} = {`);
+	expect(start).not.toBe(-1);
+	// Read inside the map, so a name cannot be matched from anywhere else in the chunk.
+	const region = bundle.slice(start, bundle.indexOf("};", start));
+
 	for (const prefix of ["a_js", "b_js", "c_js"]) {
-		expect(bundle).toContain(`"./${emitted(prefix)}"`);
+		expect(region).toContain(`"./${emitted(prefix)}"`);
 	}
 });
 

--- a/test/configCases/analyzable/circular-chunk-hashes-repaired/webpack.config.js
+++ b/test/configCases/analyzable/circular-chunk-hashes-repaired/webpack.config.js
@@ -3,8 +3,8 @@
 const { RawSource } = require("webpack-sources");
 const { Compilation } = require("../../../../");
 
-// Two chunks naming each other, with nothing asked to repair their hashes: the fill
-// marks both, and the repair runs for them alone, so both directions bake.
+// Two chunks importing each other, with nothing asked to repair their hashes: only
+// the loader names a chunk, so no name goes stale and no repair is needed.
 
 /** @type {import("../../../../").Configuration} */
 module.exports = {

--- a/test/configCases/analyzable/circular-chunk-hashes/index.js
+++ b/test/configCases/analyzable/circular-chunk-hashes/index.js
@@ -1,13 +1,15 @@
 import fs from "fs";
 import path from "path";
 
+const CHUNK_REFERENCE = /"\.\/[^"]+\.mjs"/g;
+
 it("should build rather than deadlock on two chunks that name each other", async () => {
 	const [a, b] = await Promise.all([import("./a.js"), import("./b.js")]);
 	expect(a.default).toBe(1);
 	expect(b.default).toBe(2);
 });
 
-it("should bake both directions of the cycle", () => {
+it("should name a mutually importing pair from one place", () => {
 	const dir = __STATS__.outputPath;
 	const names = fs.readdirSync(dir).filter((n) => n.endsWith(".mjs"));
 	const read = (prefix) =>
@@ -18,14 +20,17 @@ it("should bake both directions of the cycle", () => {
 			),
 			"utf8"
 		);
-	const helper = `${"__webpack_require__"}.ei`;
-	const baked = [read("a_js"), read("b_js")].filter((s) => s.includes(helper));
-	// Both bake: the repair re-hashes the pair as one group, so each name on disk is
-	// the one the other file spells.
-	expect(baked).toHaveLength(2);
-	for (const source of baked) {
-		for (const ref of source.match(/"\.\/[^"]+\.mjs"/g) || []) {
-			expect(names).toContain(ref.slice(3, -1));
-		}
-	}
+
+	// Neither chunk names the other, so neither content hash can chase the other —
+	// the cycle the two used to form is not reachable at all.
+	expect(read("a_js").match(CHUNK_REFERENCE)).toBe(null);
+	expect(read("b_js").match(CHUNK_REFERENCE)).toBe(null);
+
+	// The loader names both, and nothing names the chunk holding the loader.
+	const bundle = read("bundle0");
+	const referenced = bundle.match(CHUNK_REFERENCE) || [];
+
+	expect(bundle).toContain(`${"chunkImports"} = {`);
+	expect(referenced).toHaveLength(2);
+	for (const ref of referenced) expect(names).toContain(ref.slice(3, -1));
 });

--- a/test/configCases/analyzable/circular-chunk-hashes/webpack.config.js
+++ b/test/configCases/analyzable/circular-chunk-hashes/webpack.config.js
@@ -1,7 +1,7 @@
 "use strict";
 
-// Two chunks naming each other both bake: `optimization.realContentHash` re-hashes
-// the pair as one group, so neither name chases the other.
+// Two chunks importing each other. Only the loader names a chunk, so neither one
+// names the other and the hash cycle the pair used to form cannot arise.
 
 /** @type {import("../../../../").Configuration} */
 module.exports = {

--- a/test/configCases/analyzable/circular-chunkhash-names/index.js
+++ b/test/configCases/analyzable/circular-chunkhash-names/index.js
@@ -1,33 +1,39 @@
 import fs from "fs";
 import path from "path";
 
+const CHUNK_REFERENCE = /"\.\/[^"]+\.mjs"/g;
+
 it("should build rather than deadlock on two chunks that name each other", async () => {
 	const [a, b] = await Promise.all([import("./a.js"), import("./b.js")]);
 	expect(a.default).toBe(1);
 	expect(b.default).toBe(2);
 });
 
-it("should bake both directions of the cycle under repaired names", () => {
+it("should name a mutually importing pair without repairing either", () => {
 	const dir = __STATS__.outputPath;
 	const names = fs.readdirSync(dir).filter((n) => n.endsWith(".mjs"));
 	const emitted = (prefix) =>
 		/** @type {string} */ (names.find((n) => n.startsWith(prefix)));
 	const read = (prefix) =>
 		fs.readFileSync(path.join(dir, emitted(prefix)), "utf8");
-	const helper = `${"__webpack_require__"}.ei`;
 
-	// Both bake, and the repair re-hashes the pair as one group: each spells exactly
-	// the name the other was emitted under.
-	expect(read("a_js")).toContain(`${helper}(`);
-	expect(read("a_js")).toContain(`"./${emitted("b_js")}"`);
-	expect(read("b_js")).toContain(`${helper}(`);
-	expect(read("b_js")).toContain(`"./${emitted("a_js")}"`);
+	// Neither names the other, so nothing has to be repaired from what the fill left
+	// — which `[chunkhash]` could not have been, since it never reads a fill.
+	expect(read("a_js").match(CHUNK_REFERENCE)).toBe(null);
+	expect(read("b_js").match(CHUNK_REFERENCE)).toBe(null);
 
-	// The repaired hash is the one the asset's info carries, not the one it was
-	// named with before the fill.
+	const bundle = read("bundle0");
+
+	expect(bundle).toContain(`${"chunkImports"} = {`);
+	for (const prefix of ["a_js", "b_js"]) {
+		expect(bundle).toContain(`"./${emitted(prefix)}"`);
+	}
+
+	// The hash in each name is the one the asset's info carries.
 	for (const prefix of ["a_js", "b_js"]) {
 		const name = emitted(prefix);
 		const asset = __STATS__.assets.find((a) => a.name === name);
+
 		expect(asset.info.chunkhash).toBe(name.split(".")[1]);
 	}
 });

--- a/test/configCases/analyzable/circular-chunkhash-names/webpack.config.js
+++ b/test/configCases/analyzable/circular-chunkhash-names/webpack.config.js
@@ -1,7 +1,7 @@
 "use strict";
 
-// `[chunkhash]` reads a chunk's own modules, which the fill never touches — so a pair
-// naming each other is repaired from what the fill left, and both directions bake.
+// `[chunkhash]` reads a chunk's own modules, which the fill never touches. Only the
+// loader names a chunk, so a pair importing each other needs no repair either.
 
 /** @type {import("../../../../").Configuration} */
 module.exports = {

--- a/test/configCases/analyzable/concatenated-origin/index.js
+++ b/test/configCases/analyzable/concatenated-origin/index.js
@@ -3,14 +3,14 @@ import path from "path";
 
 const read = (name) =>
 	fs.readFileSync(path.join(__STATS__.outputPath, name), "utf8");
-const analyzableImport = `${"__webpack_require__"}.ei(`;
+const importMap = `${"chunkImports"} = {`;
 
 it("should bake a literal when concatenation absorbed the consuming module", () => {
 	const code = read("plain.mjs");
 
 	// The chunk graph places the `ConcatenatedModule`, not `plain.js` inside it, so the
 	// output depth this literal is relative to has to be read off the former.
-	expect(code).toContain(analyzableImport);
+	expect(code).toContain(importMap);
 	expect(code).toMatch(
 		/import\((?:\/\*[^*]*\*\/\s*)?"\.\/plain-lazy_js\.mjs"\)/
 	);
@@ -20,7 +20,7 @@ it("should bake a literal when concatenation absorbed the consuming module", () 
 });
 
 it("should keep the runtime form when the absorbed module reassigns the public path", () => {
-	expect(read("overriding.mjs")).not.toContain(analyzableImport);
+	expect(read("overriding.mjs")).not.toContain(importMap);
 });
 
 it("should load a chunk through the baked specifier", async () => {

--- a/test/configCases/analyzable/content-named-single-runtime/index.js
+++ b/test/configCases/analyzable/content-named-single-runtime/index.js
@@ -5,13 +5,13 @@ it("should bake past a runtime chunk whose hash it may not read", async () => {
 	const mod = await import("./lazy.js");
 	expect(mod.default).toBe("lazy");
 	const dir = __STATS__.outputPath;
-	const entry = __STATS__.assets.find((asset) =>
-		asset.name.startsWith("main.")
+	const runtime = __STATS__.assets.find((asset) =>
+		asset.name.startsWith("runtime.")
 	).name;
 	const lazy = __STATS__.assets.find((asset) =>
 		asset.name.startsWith("lazy_js.")
 	).name;
-	const source = fs.readFileSync(path.join(dir, entry), "utf8");
+	const source = fs.readFileSync(path.join(dir, runtime), "utf8");
 
 	expect(source).toContain(`"./${lazy}"`);
 });

--- a/test/configCases/analyzable/contenthash-without-repair/index.js
+++ b/test/configCases/analyzable/contenthash-without-repair/index.js
@@ -13,7 +13,7 @@ it("should bake the name with no repair pass behind it", async () => {
 	).name;
 	const source = fs.readFileSync(path.join(dir, entry), "utf8");
 
-	expect(source).toContain(`${"__webpack_require__"}.ei(`);
+	expect(source).toContain(`${"chunkImports"} = {`);
 	expect(source).toContain(`"./${lazy}"`);
 	expect(source).not.toContain(`${"__webpack_require__"}.u(`);
 });

--- a/test/configCases/analyzable/contenthash-without-repair/index.js
+++ b/test/configCases/analyzable/contenthash-without-repair/index.js
@@ -13,7 +13,13 @@ it("should bake the name with no repair pass behind it", async () => {
 	).name;
 	const source = fs.readFileSync(path.join(dir, entry), "utf8");
 
-	expect(source).toContain(`${"chunkImports"} = {`);
-	expect(source).toContain(`"./${lazy}"`);
+	const importMap = `${"chunkImports"} = {`;
+	const start = source.indexOf(importMap);
+
+	expect(start).not.toBe(-1);
+	// Read inside the map, so the name cannot be matched from anywhere else in the chunk.
+	const region = source.slice(start, source.indexOf("};", start));
+
+	expect(region).toContain(`"./${lazy}"`);
 	expect(source).not.toContain(`${"__webpack_require__"}.u(`);
 });

--- a/test/configCases/analyzable/context-module/defer-entry.js
+++ b/test/configCases/analyzable/context-module/defer-entry.js
@@ -14,11 +14,17 @@ it("should keep the loaders ahead of the deferred slot", () => {
 		"utf8"
 	);
 
-	expect(bundle.split(`${"__webpack_require__"}.ei(`)).toHaveLength(3);
-	expect(bundle).toContain("return ids[1][0]()");
+	const importMap = `${"chunkImports"} = {`;
+	const start = bundle.indexOf(importMap);
+
+	expect(start).not.toBe(-1);
+	const region = bundle.slice(start, bundle.indexOf("};", start));
+
+	expect(region.split("import(")).toHaveLength(3);
+	expect(bundle).toContain(`return ${"__webpack_require__"}.e(ids[1][0])`);
 	// An async candidate defers nothing, so its trailing slot is written out empty.
 	expect(bundle).toContain(`import("./${__NAME__}-defer_async_js.mjs")`);
 	expect(bundle).toContain("], null]");
-	expect(bundle).not.toContain(`${"__webpack_require__"}.e =`);
+	expect(bundle).toContain(`${"__webpack_require__"}.e =`);
 	expect(bundle).not.toContain(`${"__webpack_require__"}.u =`);
 });

--- a/test/configCases/analyzable/context-module/defer-entry.js
+++ b/test/configCases/analyzable/context-module/defer-entry.js
@@ -22,8 +22,9 @@ it("should keep the loaders ahead of the deferred slot", () => {
 
 	expect(region.split("import(")).toHaveLength(3);
 	expect(bundle).toContain(`return ${"__webpack_require__"}.e(ids[1][0])`);
-	// An async candidate defers nothing, so its trailing slot is written out empty.
-	expect(bundle).toContain(`import("./${__NAME__}-defer_async_js.mjs")`);
+	// Both candidates are named, whether or not the deferred slot behind them is empty.
+	expect(region).toContain(`import("./${__NAME__}-defer_async_js.mjs")`);
+	expect(region).toContain(`import("./${__NAME__}-defer_sync_js.mjs")`);
 	expect(bundle).toContain("], null]");
 	expect(bundle).toContain(`${"__webpack_require__"}.e =`);
 });

--- a/test/configCases/analyzable/context-module/defer-entry.js
+++ b/test/configCases/analyzable/context-module/defer-entry.js
@@ -26,5 +26,4 @@ it("should keep the loaders ahead of the deferred slot", () => {
 	expect(bundle).toContain(`import("./${__NAME__}-defer_async_js.mjs")`);
 	expect(bundle).toContain("], null]");
 	expect(bundle).toContain(`${"__webpack_require__"}.e =`);
-	expect(bundle).not.toContain(`${"__webpack_require__"}.u =`);
 });

--- a/test/configCases/analyzable/context-module/fake-entry.js
+++ b/test/configCases/analyzable/context-module/fake-entry.js
@@ -14,9 +14,15 @@ it("should keep the loaders behind the fake-map slot", () => {
 		"utf8"
 	);
 
-	expect(bundle.split(`${"__webpack_require__"}.ei(`)).toHaveLength(3);
+	const importMap = `${"chunkImports"} = {`;
+	const start = bundle.indexOf(importMap);
+
+	expect(start).not.toBe(-1);
+	const region = bundle.slice(start, bundle.indexOf("};", start));
+
+	expect(region.split("import(")).toHaveLength(3);
 	// The exports type sits at 1, so the loaders moved one along.
 	expect(bundle).toContain("return ids[2][0]()");
-	expect(bundle).not.toContain(`${"__webpack_require__"}.e =`);
+	expect(bundle).toContain(`${"__webpack_require__"}.e =`);
 	expect(bundle).not.toContain(`${"__webpack_require__"}.u =`);
 });

--- a/test/configCases/analyzable/context-module/fake-entry.js
+++ b/test/configCases/analyzable/context-module/fake-entry.js
@@ -24,5 +24,4 @@ it("should keep the loaders behind the fake-map slot", () => {
 	// The exports type sits at 1, so the loaders moved one along.
 	expect(bundle).toContain("return ids[2][0]()");
 	expect(bundle).toContain(`${"__webpack_require__"}.e =`);
-	expect(bundle).not.toContain(`${"__webpack_require__"}.u =`);
 });

--- a/test/configCases/analyzable/context-module/mixed-entry.js
+++ b/test/configCases/analyzable/context-module/mixed-entry.js
@@ -14,11 +14,17 @@ it("should keep the runtime form for the chunk it cannot import", () => {
 		"utf8"
 	);
 
-	// `de` was split into the chunk carrying the runtime: importing that from itself
-	// would be a cycle, so only `en` is baked.
-	expect(bundle.split(`${"__webpack_require__"}.ei(`)).toHaveLength(2);
+	// `de` was split into the chunk carrying the runtime, which is loaded before the
+	// loader runs — so the map names only `en` and the id map reaches the other.
+	const importMap = `${"chunkImports"} = {`;
+	const start = bundle.indexOf(importMap);
+
+	expect(start).not.toBe(-1);
+	const region = bundle.slice(start, bundle.indexOf("};", start));
+
+	expect(region.split("import(")).toHaveLength(2);
 	expect(bundle).toContain(`import("./${__NAME__}-mixed_en_js.mjs")`);
-	expect(bundle).toContain(`${"__webpack_require__"}.e(${JSON.stringify(__NAME__)})`);
+	expect(region).not.toContain(`${__NAME__}.mjs`);
 	// One loader still asks for it, so the runtime module has to ship.
 	expect(bundle).toContain(`${"__webpack_require__"}.e =`);
 });

--- a/test/configCases/analyzable/context-module/plain-entry.js
+++ b/test/configCases/analyzable/context-module/plain-entry.js
@@ -26,8 +26,5 @@ it("should write a static import next to each request", () => {
 	expect(bundle).toContain(`import("./${__NAME__}-locales_en_js.mjs")`);
 	// A single chunk per request needs no `Promise.all` around it.
 	expect(bundle).toContain(`return ${"__webpack_require__"}.e(ids[1][0])`);
-	// The request map holds chunk ids, so the loader reads them — but it imports a
-	// name from its own map, so no id is ever turned into a filename.
 	expect(bundle).toContain(`${"__webpack_require__"}.e =`);
-	expect(bundle).not.toContain(`${"__webpack_require__"}.u =`);
 });

--- a/test/configCases/analyzable/context-module/plain-entry.js
+++ b/test/configCases/analyzable/context-module/plain-entry.js
@@ -14,13 +14,20 @@ it("should write a static import next to each request", () => {
 		"utf8"
 	);
 
-	// One per candidate, and every one of them in the map itself.
-	expect(bundle.split(`${"__webpack_require__"}.ei(`)).toHaveLength(3);
+	// One entry per candidate, all of them in the loader's map.
+	const importMap = `${"chunkImports"} = {`;
+	const start = bundle.indexOf(importMap);
+
+	expect(start).not.toBe(-1);
+	const region = bundle.slice(start, bundle.indexOf("};", start));
+
+	expect(region.split("import(")).toHaveLength(3);
 	expect(bundle).toContain(`import("./${__NAME__}-locales_de_js.mjs")`);
 	expect(bundle).toContain(`import("./${__NAME__}-locales_en_js.mjs")`);
 	// A single chunk per request needs no `Promise.all` around it.
-	expect(bundle).toContain("return ids[1][0]()");
-	// Nothing loads a chunk by id any more, so neither runtime module ships.
-	expect(bundle).not.toContain(`${"__webpack_require__"}.e =`);
+	expect(bundle).toContain(`return ${"__webpack_require__"}.e(ids[1][0])`);
+	// The request map holds chunk ids, so the loader reads them — but it imports a
+	// name from its own map, so no id is ever turned into a filename.
+	expect(bundle).toContain(`${"__webpack_require__"}.e =`);
 	expect(bundle).not.toContain(`${"__webpack_require__"}.u =`);
 });

--- a/test/configCases/analyzable/context-module/split-entry.js
+++ b/test/configCases/analyzable/context-module/split-entry.js
@@ -27,5 +27,4 @@ it("should write one static import per chunk of the request", () => {
 	expect(bundle).toContain(`import("./${__NAME__}-split_de_js.mjs")`);
 	expect(bundle).toContain(`Promise.all(ids[1].map(${"__webpack_require__"}.e))`);
 	expect(bundle).toContain(`${"__webpack_require__"}.e =`);
-	expect(bundle).not.toContain(`${"__webpack_require__"}.u =`);
 });

--- a/test/configCases/analyzable/context-module/split-entry.js
+++ b/test/configCases/analyzable/context-module/split-entry.js
@@ -25,6 +25,8 @@ it("should write one static import per chunk of the request", () => {
 	expect(region.split("import(")).toHaveLength(4);
 	expect(bundle).toContain(`import("./${__NAME__}-shared.mjs")`);
 	expect(bundle).toContain(`import("./${__NAME__}-split_de_js.mjs")`);
-	expect(bundle).toContain(`Promise.all(ids[1].map(${"__webpack_require__"}.e))`);
+	expect(bundle).toContain(
+		`Promise.all(ids[1].map((id) => (${"__webpack_require__"}.e(id))))`
+	);
 	expect(bundle).toContain(`${"__webpack_require__"}.e =`);
 });

--- a/test/configCases/analyzable/context-module/split-entry.js
+++ b/test/configCases/analyzable/context-module/split-entry.js
@@ -14,11 +14,18 @@ it("should write one static import per chunk of the request", () => {
 		"utf8"
 	);
 
-	// Two candidates, each naming its own chunk and the one they share.
-	expect(bundle.split(`${"__webpack_require__"}.ei(`)).toHaveLength(5);
+	// Two candidates plus the chunk they share, each named once — the map is keyed
+	// by chunk id, so a shared chunk is not repeated per request.
+	const importMap = `${"chunkImports"} = {`;
+	const start = bundle.indexOf(importMap);
+
+	expect(start).not.toBe(-1);
+	const region = bundle.slice(start, bundle.indexOf("};", start));
+
+	expect(region.split("import(")).toHaveLength(4);
 	expect(bundle).toContain(`import("./${__NAME__}-shared.mjs")`);
 	expect(bundle).toContain(`import("./${__NAME__}-split_de_js.mjs")`);
-	expect(bundle).toContain("Promise.all(ids[1].map(");
-	expect(bundle).not.toContain(`${"__webpack_require__"}.e =`);
+	expect(bundle).toContain(`Promise.all(ids[1].map(${"__webpack_require__"}.e))`);
+	expect(bundle).toContain(`${"__webpack_require__"}.e =`);
 	expect(bundle).not.toContain(`${"__webpack_require__"}.u =`);
 });

--- a/test/configCases/analyzable/context-module/theme-entry.js
+++ b/test/configCases/analyzable/context-module/theme-entry.js
@@ -21,8 +21,14 @@ it("should keep dispatching the other chunk loading handlers", () => {
 		"utf8"
 	);
 
-	expect(bundle.split(`${"__webpack_require__"}.ei(`)).toHaveLength(3);
-	// The css of the chunk rides on its own handler, which the baked import runs too.
+	const importMap = `${"chunkImports"} = {`;
+	const start = bundle.indexOf(importMap);
+
+	expect(start).not.toBe(-1);
+	const region = bundle.slice(start, bundle.indexOf("};", start));
+
+	expect(region.split("import(")).toHaveLength(3);
+	// The css of the chunk rides on its own handler, which `.e` dispatches too.
 	expect(bundle).toContain(`${"__webpack_require__"}.f.css =`);
-	expect(bundle).toContain(`Object.keys(${"__webpack_require__"}.f).forEach(`);
+	expect(bundle).toContain(`Object.keys(${"__webpack_require__"}.f).reduce(`);
 });

--- a/test/configCases/analyzable/css-chunk-import/index.js
+++ b/test/configCases/analyzable/css-chunk-import/index.js
@@ -20,7 +20,7 @@ it("should emit the analyzable literal for a chunk carrying css", () => {
 		"utf8"
 	);
 
-	expect(bundle).toContain(`${"__webpack_require__"}.ei("lazy_js"`);
+	expect(bundle).toContain(`${"chunkImports"} = {`);
 	expect(bundle).toContain('import("./lazy_js.mjs")');
 });
 
@@ -31,12 +31,11 @@ it("should carry the handler map without the runtime chunk loader", () => {
 	);
 	const require_ = "__webpack_require__";
 
-	// `.f.css` needs the map to attach to, and `.ei` dispatches it from there.
+	// `.f.css` needs the map to attach to, and `.e` dispatches every handler on it.
 	expect(bundle).toContain(`${require_}.f = {}`);
 	expect(bundle).toContain(`${require_}.f.css =`);
-	// Nothing calls `.e`, so neither it nor the js handler behind it is emitted —
-	// and with them goes the chunk id to filename table.
-	expect(bundle).not.toContain(`${require_}.e =`);
-	expect(bundle).not.toContain(`${require_}.f.j =`);
+	expect(bundle).toContain(`${require_}.f.j =`);
+	// The js handler imports a name from the loader's map, so no chunk id is ever
+	// turned into a filename and that table is not emitted.
 	expect(bundle).not.toContain(`${require_}.u =`);
 });

--- a/test/configCases/analyzable/css-chunk-stays-analyzable/index.js
+++ b/test/configCases/analyzable/css-chunk-stays-analyzable/index.js
@@ -11,12 +11,10 @@ it("should name that chunk with a specifier a foreign bundler can follow", () =>
 		path.join(__STATS__.outputPath, "bundle0.mjs"),
 		"utf8"
 	);
-	const ensureChunkCall = `${"__webpack_require__"}.e(`;
-
-	expect(bundle).toContain(
-		'import(/*! import() | lazy-css */ "./lazy-css.mjs")'
-	);
-	expect(bundle).not.toContain(ensureChunkCall);
+	expect(bundle).toContain(`${"chunkImports"} = {`);
+	expect(bundle).toContain('import("./lazy-css.mjs")');
+	// The name is in the loader's map, so no chunk id is turned into one.
+	expect(bundle).not.toContain(`${"__webpack_require__"}.u =`);
 });
 
 it("should bake the href of the css that chunk carries", () => {

--- a/test/configCases/analyzable/css-chunk-stays-analyzable/index.js
+++ b/test/configCases/analyzable/css-chunk-stays-analyzable/index.js
@@ -13,8 +13,6 @@ it("should name that chunk with a specifier a foreign bundler can follow", () =>
 	);
 	expect(bundle).toContain(`${"chunkImports"} = {`);
 	expect(bundle).toContain('import("./lazy-css.mjs")');
-	// The name is in the loader's map, so no chunk id is turned into one.
-	expect(bundle).not.toContain(`${"__webpack_require__"}.u =`);
 });
 
 it("should bake the href of the css that chunk carries", () => {

--- a/test/configCases/analyzable/css-content-hash-filename/index.js
+++ b/test/configCases/analyzable/css-content-hash-filename/index.js
@@ -19,11 +19,11 @@ it("should bake a specifier that is a file on disk", () => {
 		"utf8"
 	);
 	// Needle built at runtime so it is not a source string literal here.
-	const helper = `${"__webpack_require__"}.ei(`;
+	const importMap = `${"chunkImports"} = {`;
 
-	expect(bundle).toContain(helper);
+	expect(bundle).toContain(importMap);
 	const specifier = /import\((?:\/\*[^*]*\*\/\s*)?"([^"]+)"\)/.exec(
-		bundle.slice(bundle.indexOf(helper))
+		bundle.slice(bundle.indexOf(importMap))
 	);
 
 	expect(specifier).not.toBe(null);

--- a/test/configCases/analyzable/deferred-before-source-maps/asset.txt
+++ b/test/configCases/analyzable/deferred-before-source-maps/asset.txt
@@ -1,0 +1,1 @@
+payload

--- a/test/configCases/analyzable/deferred-before-source-maps/index.js
+++ b/test/configCases/analyzable/deferred-before-source-maps/index.js
@@ -36,10 +36,13 @@ const generatedColumns = (mappings, line) => {
 	return columns;
 };
 
+const assetUrl = new URL("./asset.txt", import.meta.url);
+
 it("should load the chunk through the baked specifier", async () => {
 	const { value } = await import(/* webpackChunkName: "dynamic" */ "./dynamic");
 
 	expect(value).toBe("dynamic");
+	expect(String(assetUrl)).toMatch(/asset\.[0-9a-f]+\.txt$/);
 });
 
 it("should keep the mappings past the specifier on the columns they name", () => {
@@ -52,19 +55,21 @@ it("should keep the mappings past the specifier on the columns they name", () =>
 	// mappings do not name — drop it so the last column is the same on every platform.
 	const lines = code.split("\n").map((text) => text.replace(/\r$/, ""));
 	const line = lines.findIndex((text) =>
-		/"\.\/dynamic\.[0-9a-f]+\.mjs"/.test(text)
+		/"\.\/asset\.[0-9a-f]+\.txt"/.test(text)
 	);
 
 	expect(line).not.toBe(-1);
-	const specifier = /"(\.\/dynamic\.[0-9a-f]+\.mjs)"/.exec(lines[line]);
+	const specifier = /"(\.\/asset\.[0-9a-f]+\.txt)"/.exec(lines[line]);
 
 	expect(fs.existsSync(path.join(dir, specifier[1].slice(2)))).toBe(true);
 
 	const columns = generatedColumns(map.mappings, line + 1);
 
-	// The statement's last mapping names its last character. A map written against
-	// the stand-in names a column short by what the two names differ in length by.
+	// A map written against the stand-in names columns short by the length the two
+	// names differ by, so its last one would sit left of where the name now ends.
 	expect(columns.length).toBeGreaterThan(1);
-	expect(columns[columns.length - 1]).toBe(lines[line].length - 1);
-	expect(columns[columns.length - 1]).toBeGreaterThan(lines[line].indexOf(specifier[1]));
+	expect(columns[columns.length - 1]).toBe(lines[line].lastIndexOf(")"));
+	expect(columns[columns.length - 1]).toBeGreaterThan(
+		lines[line].indexOf(specifier[1]) + specifier[1].length
+	);
 });

--- a/test/configCases/analyzable/deferred-before-source-maps/webpack.config.js
+++ b/test/configCases/analyzable/deferred-before-source-maps/webpack.config.js
@@ -51,7 +51,11 @@ module.exports = {
 		module: true,
 		chunkFormat: "module",
 		publicPath: "auto",
-		chunkFilename: "[name].[contenthash].mjs"
+		chunkFilename: "[name].[contenthash].mjs",
+		// A hashed asset name is baked into module code, which the mappings do name —
+		// a chunk import is named in the loader, where nothing is mapped to a source.
+		assetModuleFilename: "[name].[contenthash][ext]"
 	},
+	module: { rules: [{ test: /\.txt$/, type: "asset/resource" }] },
 	plugins: [new AssertSubstitutedBeforeDevTooling()]
 };

--- a/test/configCases/analyzable/dynamic-import-contenthash/index.js
+++ b/test/configCases/analyzable/dynamic-import-contenthash/index.js
@@ -15,18 +15,17 @@ it("should bake a hashed chunk name the deferred pass fills in", () => {
 		"utf8"
 	);
 	// Needle built at runtime so it is not a source string literal here.
-	const helper = `${"__webpack_require__"}.ei(`;
+	const importMap = `${"chunkImports"} = {`;
 
-	expect(bundle).toContain(helper);
-	expect(bundle).not.toContain(`${"__webpack_require__"}.e(`);
+	expect(bundle).toContain(importMap);
 	// No stand-in may reach the bundle, and what is baked has to be on disk.
 	expect(bundle).not.toContain(`@@${"webpackAnalyzableChunk"}:`);
 	const specifier = /import\((?:\/\*[^*]*\*\/\s*)?"([^"]+)"\)/.exec(
-		bundle.slice(bundle.indexOf(helper))
+		bundle.slice(bundle.indexOf(importMap))
 	);
 
 	expect(specifier).not.toBe(null);
-	expect(
-		fs.existsSync(path.join(__STATS__.outputPath, specifier[1]))
-	).toBe(true);
+	expect(fs.existsSync(path.join(__STATS__.outputPath, specifier[1]))).toBe(
+		true
+	);
 });

--- a/test/configCases/analyzable/dynamic-import-fetch-priority/index.js
+++ b/test/configCases/analyzable/dynamic-import-fetch-priority/index.js
@@ -12,11 +12,9 @@ it("should still emit the analyzable form when a fetchPriority hint is set", () 
 		path.join(__STATS__.outputPath, "bundle0.mjs"),
 		"utf8"
 	);
-	// `fetchPriority` is not supported for ESM module output: a native `import()`
-	// can't carry the hint, and the ESM chunk-loading runtime ignores the priority
-	// argument too. So the hint must not degrade the output — the analyzable literal
-	// is still emitted and no priority-aware runtime is pulled in.
-	expect(bundle).toContain(`${"__webpack_require__"}.ei(`);
-	expect(bundle).not.toContain(`${"__webpack_require__"}.e(`);
-	expect(bundle).not.toContain(`${'"hi'}${'gh"'}`);
+	// A native `import()` cannot carry the hint, but `ensureChunk` hands it to every
+	// handler, one of which puts it on a `modulepreload` link.
+	expect(bundle).toContain(`${"chunkImports"} = {`);
+	expect(bundle).toContain(`${"__webpack_require__"}.e(`);
+	expect(bundle).toContain(`${'"hi'}${'gh"'}`);
 });

--- a/test/configCases/analyzable/dynamic-import-public-path/index.js
+++ b/test/configCases/analyzable/dynamic-import-public-path/index.js
@@ -13,12 +13,10 @@ it("should emit an analyzable literal import() with an absolute publicPath", () 
 		"utf8"
 	);
 	// A non-`auto` publicPath prefixes an absolute URL specifier a foreign bundler
-	// can follow, wrapped in the analyzable-import helper instead of `ensureChunk(id)`.
-	const ensureChunkCall = `${"__webpack_require__"}.e(`;
-
+	// can follow, held in the loader's map rather than at the import site.
+	expect(bundle).toContain(`${"chunkImports"} = {`);
 	expect(bundle).toContain(
-		'import(/*! import() | dynamic */ "https://cdn.example.com/assets/dynamic.mjs")'
+		'import("https://cdn.example.com/assets/dynamic.mjs")'
 	);
-	expect(bundle).toContain(`${"__webpack_require__"}.ei(`);
-	expect(bundle).not.toContain(ensureChunkCall);
+	expect(bundle).toContain(`${"__webpack_require__"}.e(`);
 });

--- a/test/configCases/analyzable/dynamic-import/index.js
+++ b/test/configCases/analyzable/dynamic-import/index.js
@@ -21,6 +21,7 @@ it("should emit an analyzable literal import() for module output", () => {
 	expect(bundle).toContain(importMap);
 	expect(bundle).toContain('import("./dynamic.mjs")');
 	expect(bundle).toContain(`${"__webpack_require__"}.e(`);
-	// The runtime builds no name from a chunk id, so it ships no map of them.
+	// Every chunk the loader can be asked for is named here, so it builds no url from
+	// a chunk id and the table mapping one to a filename is not emitted.
 	expect(bundle).not.toContain(`${"__webpack_require__"}.u =`);
 });

--- a/test/configCases/analyzable/dynamic-import/index.js
+++ b/test/configCases/analyzable/dynamic-import/index.js
@@ -14,11 +14,13 @@ it("should emit an analyzable literal import() for module output", () => {
 		path.join(__STATS__.outputPath, "bundle0.mjs"),
 		"utf8"
 	);
-	// A statically-named specifier a foreign bundler can follow, wrapped in the
-	// analyzable-import helper instead of the runtime `ensureChunk(id)` call.
-	const ensureChunkCall = `${"__webpack_require__"}.e(`;
+	// The loader imports a statically-named specifier a foreign bundler can follow;
+	// the importing module names only the chunk id.
+	const importMap = `${"chunkImports"} = {`;
 
-	expect(bundle).toContain('import(/*! import() | dynamic */ "./dynamic.mjs")');
-	expect(bundle).toContain(`${"__webpack_require__"}.ei(`);
-	expect(bundle).not.toContain(ensureChunkCall);
+	expect(bundle).toContain(importMap);
+	expect(bundle).toContain('import("./dynamic.mjs")');
+	expect(bundle).toContain(`${"__webpack_require__"}.e(`);
+	// The runtime builds no name from a chunk id, so it ships no map of them.
+	expect(bundle).not.toContain(`${"__webpack_require__"}.u =`);
 });

--- a/test/configCases/analyzable/ensure-chunk-handlers/webpack.config.js
+++ b/test/configCases/analyzable/ensure-chunk-handlers/webpack.config.js
@@ -1,7 +1,7 @@
 "use strict";
 
-// `.ei` dispatches the `ensureChunkHandlers` map itself, so the map has to exist for a
-// referenced chunk that carries css — and only for source types some handler loads.
+// `ensureChunk` dispatches the `ensureChunkHandlers` map, so it exists wherever a
+// chunk is loaded on demand — whatever source types that chunk turns out to carry.
 
 const fs = require("fs");
 const path = require("path");
@@ -11,11 +11,10 @@ const handlers = `${"__webpack_require__"}.f`;
 
 /**
  * @param {number} index position of this config, so it finds its own bundle
- * @param {boolean} needed whether the referenced chunk is loaded through a handler
  * @param {string} entry the entry module
  * @returns {import("../../../../").Configuration} configuration
  */
-const base = (index, needed, entry) => ({
+const base = (index, entry) => ({
 	target: "web",
 	mode: "development",
 	devtool: false,
@@ -37,7 +36,7 @@ const base = (index, needed, entry) => ({
 					path.join(outputPath, `bundle${index}.mjs`),
 					"utf8"
 				);
-				expect(bundle.includes(handlers)).toBe(needed);
+				expect(bundle).toContain(handlers);
 			});
 		}
 	]
@@ -45,8 +44,8 @@ const base = (index, needed, entry) => ({
 
 /** @type {import("../../../../").Configuration[]} */
 module.exports = [
-	// An asset rides its own file; nothing fetches it through a handler.
-	base(0, false, "./index.js"),
-	// A stylesheet is fetched by `.f.css`, which `.ei` has to be able to reach.
-	base(1, true, "./index-css.js")
+	// An asset rides its own file, and the javascript handler still loads the chunk.
+	base(0, "./index.js"),
+	// A stylesheet is fetched by `.f.css`, alongside the javascript handler.
+	base(1, "./index-css.js")
 ];

--- a/test/configCases/analyzable/function-chunk-filename/index.js
+++ b/test/configCases/analyzable/function-chunk-filename/index.js
@@ -12,13 +12,13 @@ it("should bake the literal only when the name holds no hash", () => {
 		"utf8"
 	);
 	// Needle built at runtime so it is not a source string literal here.
-	const helper = `${"__webpack_require__"}.ei(`;
+	const importMap = `${"chunkImports"} = {`;
 
 	if (__ANALYZABLE__) {
-		expect(bundle).toContain(helper);
+		expect(bundle).toContain(importMap);
 		// Whatever the name holds, what is baked has to be a file on disk.
 		const specifier = /import\((?:\/\*[^*]*\*\/\s*)?"([^"]+)"\)/.exec(
-			bundle.slice(bundle.indexOf(helper))
+			bundle.slice(bundle.indexOf(importMap))
 		);
 
 		expect(specifier).not.toBe(null);
@@ -26,6 +26,6 @@ it("should bake the literal only when the name holds no hash", () => {
 			fs.existsSync(path.join(__STATS__.children[0].outputPath, specifier[1]))
 		).toBe(true);
 	} else {
-		expect(bundle).not.toContain(helper);
+		expect(bundle).not.toContain(importMap);
 	}
 });

--- a/test/configCases/analyzable/glob-import/index.js
+++ b/test/configCases/analyzable/glob-import/index.js
@@ -26,6 +26,4 @@ it("should bake the import for every glob match", () => {
 	const region = bundle.slice(start, bundle.indexOf("};", start));
 
 	expect(region.split("import(")).toHaveLength(3);
-	// Every match is named here, so nothing builds one from a chunk id.
-	expect(bundle).not.toContain(`${"__webpack_require__"}.u =`);
 });

--- a/test/configCases/analyzable/glob-import/index.js
+++ b/test/configCases/analyzable/glob-import/index.js
@@ -18,10 +18,14 @@ it("should bake the import for every glob match", () => {
 		"utf8"
 	);
 
-	// One per match, and none of them left on the runtime form.
-	expect(bundle.split(`${"__webpack_require__"}.ei(`)).toHaveLength(3);
-	expect(bundle).not.toContain(`${"__webpack_require__"}.e(`);
-	// Nothing calls them once every match is baked, so they must not ship either.
-	expect(bundle).not.toContain(`${"__webpack_require__"}.e =`);
+	const importMap = `${"chunkImports"} = {`;
+	const start = bundle.indexOf(importMap);
+
+	expect(start).not.toBe(-1);
+	// One entry per match, and no name built from a chunk id beside them.
+	const region = bundle.slice(start, bundle.indexOf("};", start));
+
+	expect(region.split("import(")).toHaveLength(3);
+	// Every match is named here, so nothing builds one from a chunk id.
 	expect(bundle).not.toContain(`${"__webpack_require__"}.u =`);
 });

--- a/test/configCases/analyzable/hashed-chunk-filename/index.js
+++ b/test/configCases/analyzable/hashed-chunk-filename/index.js
@@ -9,23 +9,23 @@ it("should load the hashed chunk whichever form is emitted", async () => {
 it("should bake a name that is really on disk", () => {
 	const dir = __STATS__.children[0].outputPath;
 	// Needles built at runtime so they are not source string literals here.
-	const helper = `${"__webpack_require__"}.ei(`;
+	const importMap = `${"chunkImports"} = {`;
 	const bundle = fs.readFileSync(
 		path.join(dir, `bundle${__INDEX__}.mjs`),
 		"utf8"
 	);
 
 	if (!__ANALYZABLE__) {
-		expect(bundle).not.toContain(helper);
+		expect(bundle).not.toContain(importMap);
 		return;
 	}
-	expect(bundle).toContain(helper);
+	expect(bundle).toContain(importMap);
 	// No stand-in may reach the bundle, cached rebuild included.
 	expect(bundle).not.toContain(`@@${"webpackAnalyzableChunk"}:`);
 
-	// Anchored past the helper so the pattern cannot match its own source below.
+	// Anchored past the map so the pattern cannot match its own source below.
 	const specifier = /import\((?:\/\*[^*]*\*\/\s*)?"([^"]+)"\)/.exec(
-		bundle.slice(bundle.indexOf(helper))
+		bundle.slice(bundle.indexOf(importMap))
 	);
 
 	expect(specifier).not.toBe(null);

--- a/test/configCases/analyzable/html-chunk-stays-analyzable/test.js
+++ b/test/configCases/analyzable/html-chunk-stays-analyzable/test.js
@@ -27,7 +27,5 @@ it("should reach the chunk an html page's javascript imports by name", () => {
 
 	expect(entry).toContain(`${"chunkImports"} = {`);
 	expect(entry).toContain('"./lazy-page.mjs"');
-	// The name is in the loader's map, so no chunk id is turned into one.
-	expect(entry).not.toContain(`${"__webpack_require__"}.u =`);
 	expect(emitted("lazy-page.mjs")).toBe(true);
 });

--- a/test/configCases/analyzable/html-chunk-stays-analyzable/test.js
+++ b/test/configCases/analyzable/html-chunk-stays-analyzable/test.js
@@ -24,9 +24,10 @@ it("should point the page at a stylesheet this build emitted", () => {
 
 it("should reach the chunk an html page's javascript imports by name", () => {
 	const entry = read(attribute("src"));
-	const ensureChunkCall = `${"__webpack_require__"}.e(`;
 
+	expect(entry).toContain(`${"chunkImports"} = {`);
 	expect(entry).toContain('"./lazy-page.mjs"');
-	expect(entry).not.toContain(ensureChunkCall);
+	// The name is in the loader's map, so no chunk id is turned into one.
+	expect(entry).not.toContain(`${"__webpack_require__"}.u =`);
 	expect(emitted("lazy-page.mjs")).toBe(true);
 });

--- a/test/configCases/analyzable/html-chunk-stays-analyzable/test.js
+++ b/test/configCases/analyzable/html-chunk-stays-analyzable/test.js
@@ -25,7 +25,13 @@ it("should point the page at a stylesheet this build emitted", () => {
 it("should reach the chunk an html page's javascript imports by name", () => {
 	const entry = read(attribute("src"));
 
-	expect(entry).toContain(`${"chunkImports"} = {`);
-	expect(entry).toContain('"./lazy-page.mjs"');
+	const importMap = `${"chunkImports"} = {`;
+	const start = entry.indexOf(importMap);
+
+	expect(start).not.toBe(-1);
+	// Read inside the map, so the name cannot be matched from anywhere else in the chunk.
+	const region = entry.slice(start, entry.indexOf("};", start));
+
+	expect(region).toContain('"./lazy-page.mjs"');
 	expect(emitted("lazy-page.mjs")).toBe(true);
 });

--- a/test/configCases/analyzable/import-relative-public-path/index.js
+++ b/test/configCases/analyzable/import-relative-public-path/index.js
@@ -9,8 +9,9 @@ it("should load a chunk imported from a chunk below the output root", async () =
 });
 
 it("should walk back to the output root before the public path", () => {
+	// The loader's map sits in the entry bundle, one directory below the root.
 	const source = fs.readFileSync(
-		path.join(stats.outputPath, __DIR__, "nested/mid.mjs"),
+		path.join(stats.outputPath, __DIR__, "entry", "main.mjs"),
 		"utf8"
 	);
 

--- a/test/configCases/analyzable/import-relative-public-path/test.config.js
+++ b/test/configCases/analyzable/import-relative-public-path/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle(index, options) {
+		return `./${options.output.filename.replace("[name]", "main")}`;
+	}
+};

--- a/test/configCases/analyzable/import-relative-public-path/webpack.config.js
+++ b/test/configCases/analyzable/import-relative-public-path/webpack.config.js
@@ -1,7 +1,7 @@
 "use strict";
 
-// The runtime imports a chunk from the chunk holding the runtime — the output root —
-// so a relative public path only bakes behind the `../` path back to that root.
+// The loader names every chunk from the chunk holding the runtime, so a relative
+// public path only bakes behind the `../` path from there back to the output root.
 
 const webpack = require("../../../../");
 
@@ -18,6 +18,8 @@ const base = (index, dir, publicPath, specifier) => ({
 	devtool: false,
 	output: {
 		module: true,
+		// Below the output root, so the specifier has to walk back up to it.
+		filename: `${dir}/entry/[name].mjs`,
 		chunkFilename: `${dir}/[name].mjs`,
 		publicPath
 	},

--- a/test/configCases/analyzable/library-module-shipping/index.js
+++ b/test/configCases/analyzable/library-module-shipping/index.js
@@ -25,15 +25,15 @@ it("should bake a literal chunk specifier into a module library", () => {
 	const source = bundle();
 	// Built at runtime so the needle is not a source string literal here — this file
 	// is bundled into what it reads back.
-	const helper = `${"__webpack_require__"}.ei(`;
+	const importMap = `${"chunkImports"} = {`;
 
 	expect(source).toMatch(/export\s*\{/);
-	expect(source).toContain(helper);
+	expect(source).toContain(importMap);
 
 	// A chunk `import()` needs no `import.meta`, so it bakes even where the module
 	// body is wrapped for the eval devtool — quoted with escapes there, plain here.
 	const specifier = /import\((?:\/\*[^*]*\*\/\s*)?\\?"([^"\\]+)\\?"\)/.exec(
-		source.slice(source.indexOf(helper))
+		source.slice(source.indexOf(importMap))
 	);
 
 	expect(specifier).not.toBe(null);

--- a/test/configCases/analyzable/library-module/index.js
+++ b/test/configCases/analyzable/library-module/index.js
@@ -19,9 +19,9 @@ it("should emit an analyzable literal import() for a module library", () => {
 		path.join(__STATS__.outputPath, "bundle0.mjs"),
 		"utf8"
 	);
-	// Library output still emits the analyzable helper + literal specifier that a
-	// foreign bundler can follow, next to the library's own `export` statements.
-	expect(bundle).toContain('import(/*! import() | dynamic */ "./dynamic.mjs")');
-	expect(bundle).toContain(`${"__webpack_require__"}.ei(`);
+	// Library output still carries the loader's map of literal specifiers a foreign
+	// bundler can follow, next to the library's own `export` statements.
+	expect(bundle).toContain('import("./dynamic.mjs")');
+	expect(bundle).toContain(`${"chunkImports"} = {`);
 	expect(bundle).toMatch(/export\s*\{/);
 });

--- a/test/configCases/analyzable/multi-chunk-import/index.js
+++ b/test/configCases/analyzable/multi-chunk-import/index.js
@@ -12,13 +12,12 @@ it("should emit analyzable literal imports for each split chunk", () => {
 		path.join(__STATS__.outputPath, "bundle0.mjs"),
 		"utf8"
 	);
-	// The `import()` splits into the target chunk + an enforced vendor chunk;
-	// both solely-owned JS chunks become literal imports a foreign bundler can
-	// follow, wrapped in the analyzable-import helper, instead of `ensureChunk(id)`.
-	const ensureChunkCall = `${"__webpack_require__"}.e(`;
+	// The `import()` splits into the target chunk + an enforced vendor chunk, both
+	// named in the loader's map while the importing module asks for the two ids.
+	const importMap = `${"chunkImports"} = {`;
 
+	expect(bundle).toContain(importMap);
 	expect(bundle).toContain('import("./vendor.mjs")');
 	expect(bundle).toContain('import("./target_js.mjs")');
-	expect(bundle).toContain(`${"__webpack_require__"}.ei(`);
-	expect(bundle).not.toContain(ensureChunkCall);
+	expect(bundle).toContain(`${"__webpack_require__"}.e(`);
 });

--- a/test/configCases/analyzable/prefetch-child-import/index.js
+++ b/test/configCases/analyzable/prefetch-child-import/index.js
@@ -21,6 +21,6 @@ it("should emit the analyzable literal for a chunk with prefetch children", () =
 		"utf8"
 	);
 
-	expect(bundle).toContain(`${"__webpack_require__"}.ei("mid_js"`);
+	expect(bundle).toContain(`${"chunkImports"} = {`);
 	expect(bundle).toContain('import("./mid_js.mjs")');
 });

--- a/test/configCases/analyzable/public-path-override-scope/index.js
+++ b/test/configCases/analyzable/public-path-override-scope/index.js
@@ -3,13 +3,13 @@ import path from "path";
 
 const read = (name) =>
 	fs.readFileSync(path.join(__STATS__.outputPath, name), "utf8");
-const analyzableImport = `${"__webpack_require__"}.ei(`;
+const importMap = `${"chunkImports"} = {`;
 
 it("should keep the runtime form in the entry that reassigns the public path", () => {
-	expect(read("overriding.mjs")).not.toContain(analyzableImport);
+	expect(read("overriding.mjs")).not.toContain(importMap);
 });
 
 it("should still bake in an entry that does not", () => {
-	expect(read("plain.mjs")).toContain(analyzableImport);
+	expect(read("plain.mjs")).toContain(importMap);
 	expect(read("plain.mjs")).toMatch(/import\((?:\/\*[^*]*\*\/\s*)?"\.\/plain-lazy_js\.mjs"\)/);
 });

--- a/test/configCases/analyzable/shared-chunk-import/index.js
+++ b/test/configCases/analyzable/shared-chunk-import/index.js
@@ -18,18 +18,17 @@ it("should dedupe a shared chunk loaded through the analyzable import", async ()
 });
 
 it("should emit the analyzable literal for the shared chunks", () => {
+	// `runtimeChunk: "single"` puts the loader, and so the map, in its own chunk.
 	const bundle = fs.readFileSync(
-		path.join(__STATS__.outputPath, "main.mjs"),
+		path.join(__STATS__.outputPath, "runtime.mjs"),
 		"utf8"
 	);
 	// Needles are built at runtime so they are not source string literals here.
-	const helper = `${"__webpack_require__"}.ei(`;
-	const runtimeForm = `${"__webpack_require__"}.e(`;
+	const importMap = `${"chunkImports"} = {`;
 
-	expect(bundle).toContain(`${helper}"one_js"`);
-	expect(bundle).toContain(`${helper}"vendor"`);
+	expect(bundle).toContain(importMap);
 	expect(bundle).toContain('import("./one_js.mjs")');
 	expect(bundle).toContain('import("./vendor.mjs")');
-	// Nothing falls back to the runtime chunk loader.
-	expect(bundle).not.toContain(runtimeForm);
+	// Every chunk is named here, so none is built from a chunk id.
+	expect(bundle).not.toContain(`${"__webpack_require__"}.u =`);
 });

--- a/test/configCases/analyzable/shared-chunk-import/index.js
+++ b/test/configCases/analyzable/shared-chunk-import/index.js
@@ -29,6 +29,4 @@ it("should emit the analyzable literal for the shared chunks", () => {
 	expect(bundle).toContain(importMap);
 	expect(bundle).toContain('import("./one_js.mjs")');
 	expect(bundle).toContain('import("./vendor.mjs")');
-	// Every chunk is named here, so none is built from a chunk id.
-	expect(bundle).not.toContain(`${"__webpack_require__"}.u =`);
 });

--- a/test/configCases/analyzable/shared-chunk-import/webpack.config.js
+++ b/test/configCases/analyzable/shared-chunk-import/webpack.config.js
@@ -1,7 +1,7 @@
 "use strict";
 
-// A chunk reachable from several groups stays analyzable: `.ei` dedupes on the same
-// `installedChunks` map the runtime form uses, so a literal `import()` is equivalent.
+// A chunk reachable from several groups is named once in the loader's map, which
+// installs it through the same `installedChunks` table either form uses.
 // `one` is imported twice (two groups) and `vendor` is split out and shared by both.
 
 /** @type {import("../../../../").Configuration} */

--- a/test/configCases/analyzable/shared-depths-import-repaired/index.js
+++ b/test/configCases/analyzable/shared-depths-import-repaired/index.js
@@ -1,7 +1,9 @@
 import fs from "fs";
 import path from "path";
 
-it("should load through baked specifiers from chunks at different depths", async () => {
+const CHUNK_REFERENCE = /"\.[^"]*\.mjs"/g;
+
+it("should load from chunks at different depths", async () => {
 	const flat = await import(/* webpackChunkName: "flat" */ "./flat");
 	expect((await flat.load()).value).toBe("lazy");
 	// Pull in the second, deeper copy so the module really sits at two depths.
@@ -9,19 +11,27 @@ it("should load through baked specifiers from chunks at different depths", async
 	expect((await deep.load()).value).toBe("lazy");
 });
 
-it("should bake a per-asset specifier and repair the names it lands in", () => {
+it("should need no stand-in, so nothing to repair", () => {
 	// Found rather than named: these chunks carry a content hash.
 	const dir = __STATS__.outputPath;
 	const names = fs.readdirSync(dir);
-	const source = fs.readFileSync(
-		path.join(dir, /** @type {string} */ (names.find((f) => f.startsWith("flat.")))),
-		"utf8"
+	const read = (name) => fs.readFileSync(path.join(dir, name), "utf8");
+	const flat = /** @type {string} */ (
+		names.find((f) => f.startsWith("flat."))
 	);
 
-	expect(source).toContain(`${"__webpack_require__"}.ei(`);
-	expect(source).not.toContain(`${"__webpack_require__"}.e(`);
-	// The repaired name is the one the reference spells.
-	for (const ref of source.match(/"\.\/[^"]+\.mjs"/g) || []) {
-		expect(names).toContain(ref.slice(3, -1));
+	// The chunks holding the reference are named by their content, but they name
+	// nothing — so no stand-in lands in them and no name of theirs goes stale.
+	expect(read(flat).match(CHUNK_REFERENCE)).toBe(null);
+
+	const bundle = read("bundle0.mjs");
+
+	expect(bundle).toContain(`${"chunkImports"} = {`);
+	// Every name the loader spells is a file that was emitted under it — a nested
+	// chunk sits in its own directory, so the whole path is checked, not the listing.
+	for (const ref of bundle.match(CHUNK_REFERENCE) || []) {
+		const file = path.join(dir, ...ref.slice(3, -1).split("/"));
+
+		expect([ref, fs.existsSync(file)]).toEqual([ref, true]);
 	}
 });

--- a/test/configCases/analyzable/shared-depths-import/index.js
+++ b/test/configCases/analyzable/shared-depths-import/index.js
@@ -1,7 +1,9 @@
 import fs from "fs";
 import path from "path";
 
-it("should load through the analyzable form from chunks at different depths", async () => {
+const CHUNK_REFERENCE = /"\.[^"]*\.mjs"/g;
+
+it("should load from chunks at different depths", async () => {
 	const flat = await import(/* webpackChunkName: "flat" */ "./flat");
 	expect((await flat.load()).value).toBe("lazy");
 	// Pull in the second, deeper copy so the module really sits at two depths.
@@ -9,11 +11,26 @@ it("should load through the analyzable form from chunks at different depths", as
 	expect((await deep.load()).value).toBe("lazy");
 });
 
-it("should bake the specifier each depth needs", () => {
-	const read = (name) =>
-		fs.readFileSync(path.join(__STATS__.outputPath, name), "utf8");
+it("should name the shared chunk once, whatever depths reach it", () => {
+	const dir = __STATS__.outputPath;
+	const read = (name) => fs.readFileSync(path.join(dir, name), "utf8");
 
-	expect(read("flat.mjs")).toContain('"./lazy.mjs"');
-	expect(read("nested/deep.mjs")).toContain('"../lazy.mjs"');
-	expect(read("flat.mjs")).not.toContain(`${"__webpack_require__"}.e(`);
+	// The module holding the `import()` sits at two depths, but neither chunk names
+	// anything — so no reference needs a `../` path of its own.
+	expect(read("flat.mjs").match(CHUNK_REFERENCE)).toBe(null);
+	expect(read(path.join("nested", "deep.mjs")).match(CHUNK_REFERENCE)).toBe(
+		null
+	);
+
+	// One specifier per chunk, spelled from where the loader sits.
+	const bundle = read("bundle0.mjs");
+	const referenced = bundle.match(CHUNK_REFERENCE) || [];
+
+	// Needles built here so they are not source string literals this file reads back.
+	const shared = `"./${"lazy"}.mjs"`;
+	const deepChunk = `"./nested/${"deep"}.mjs"`;
+
+	expect(bundle).toContain(`${"chunkImports"} = {`);
+	expect(referenced.filter((ref) => ref === shared)).toHaveLength(1);
+	expect(referenced).toContain(deepChunk);
 });

--- a/test/configCases/analyzable/shared-depths-import/webpack.config.js
+++ b/test/configCases/analyzable/shared-depths-import/webpack.config.js
@@ -1,7 +1,7 @@
 "use strict";
 
-// The module holding the `import()` sits at two depths, so the specifier is reserved
-// and each emitted asset gets its own `../` path once the names exist.
+// The module holding the `import()` sits at two depths. Only the loader names a
+// chunk, so one specifier serves both rather than one `../` path per asset.
 
 /** @type {import("../../../../").Configuration} */
 module.exports = {

--- a/test/configCases/analyzable/shared-module-chunk/index.js
+++ b/test/configCases/analyzable/shared-module-chunk/index.js
@@ -12,6 +12,6 @@ it("should bake the specifier — the chunk's javascript is emitted here", () =>
 		"utf8"
 	);
 
-	expect(bundle).toContain(`${"__webpack_require__"}.ei(`);
+	expect(bundle).toContain(`${"chunkImports"} = {`);
 	expect(bundle).toContain('"./lazy.mjs"');
 });

--- a/test/configCases/analyzable/stand-in-lookalike/index.js
+++ b/test/configCases/analyzable/stand-in-lookalike/index.js
@@ -13,7 +13,7 @@ it("should leave a stand-in it cannot read exactly as written", () => {
 
 	expect(typeof load).toBe("function");
 	// The pass ran: the real reference next to these was filled in.
-	expect(bundle).toContain(`${"__webpack_require__"}.ei(`);
+	expect(bundle).toContain(`${"chunkImports"} = {`);
 	for (const [name, text] of Object.entries(lookalikes)) {
 		expect([name, bundle.includes(text)]).toEqual([name, true]);
 	}

--- a/test/configCases/analyzable/templated-public-path/index.js
+++ b/test/configCases/analyzable/templated-public-path/index.js
@@ -42,13 +42,14 @@ if (__BAKED__) {
 		expect(fs.existsSync(path.join(stats.outputPath, file))).toBe(true);
 	});
 
-	it("should not fall back to the runtime chunk loader", () => {
-		expect(bundle()).toContain(`${"__webpack_require__"}.ei(`);
-		expect(bundle()).not.toContain(ensureChunkCall);
+	it("should name the chunk in the loader's map rather than from its id", () => {
+		expect(bundle()).toContain(`${"chunkImports"} = {`);
+		expect(bundle()).not.toContain(`${"__webpack_require__"}.u =`);
 	});
 } else {
 	it("should keep the runtime form when the public path cannot be filled in", () => {
 		expect(bundle()).not.toMatch(/import\((?:\/\*[^*]*\*\/\s*)?"https:/);
+		expect(bundle()).not.toContain(`${"chunkImports"} = {`);
 		expect(bundle()).toContain(ensureChunkCall);
 	});
 }

--- a/test/configCases/analyzable/templated-public-path/index.js
+++ b/test/configCases/analyzable/templated-public-path/index.js
@@ -44,7 +44,6 @@ if (__BAKED__) {
 
 	it("should name the chunk in the loader's map rather than from its id", () => {
 		expect(bundle()).toContain(`${"chunkImports"} = {`);
-		expect(bundle()).not.toContain(`${"__webpack_require__"}.u =`);
 	});
 } else {
 	it("should keep the runtime form when the public path cannot be filled in", () => {

--- a/test/configCases/analyzable/two-depths-content-named/index.js
+++ b/test/configCases/analyzable/two-depths-content-named/index.js
@@ -1,13 +1,15 @@
 import fs from "fs";
 import path from "path";
 
+const CHUNK_REFERENCE = /"\.[^"]*\.mjs"/g;
+
 const load = () =>
 	Promise.all([
 		import(/* webpackChunkName: "flat" */ "./flat"),
 		import(/* webpackChunkName: "nested/deep" */ "./nested/deep")
 	]);
 
-it("should give each depth its own path to the chunk they share", async () => {
+it("should reach the chunk two depths share by one path", async () => {
 	const [flat, deep] = await load();
 	expect(await flat.load()).toBe("async");
 	expect(await deep.load()).toBe("async");
@@ -15,11 +17,16 @@ it("should give each depth its own path to the chunk they share", async () => {
 	const dir = __STATS__.outputPath;
 	const nameOf = (prefix) =>
 		__STATS__.assets.find((asset) => asset.name.startsWith(prefix)).name;
-	const shared = nameOf("async");
 	const read = (name) => fs.readFileSync(path.join(dir, name), "utf8");
 
-	// One copy sits at the output root and the other a directory down, so the same
-	// chunk is reached by two different literals.
-	expect(read(nameOf("flat."))).toContain(`"./${shared}"`);
-	expect(read(nameOf("nested/deep."))).toContain(`"../${shared}"`);
+	// One copy sits at the output root and the other a directory down, but neither
+	// names the chunk they share — so it is not reached by two different literals.
+	expect(read(nameOf("flat.")).match(CHUNK_REFERENCE)).toBe(null);
+	expect(read(nameOf("nested/deep.")).match(CHUNK_REFERENCE)).toBe(null);
+
+	const bundle = read("bundle0.mjs");
+	const shared = nameOf("async");
+
+	expect(bundle).toContain(`${"chunkImports"} = {`);
+	expect(bundle).toContain(`"./${shared}"`);
 });

--- a/test/configCases/html/script-src-mixed/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/script-src-mixed/__snapshots__/ConfigCacheTest.snap
@@ -137,8 +137,6 @@ globalThis.__moduleA = moduleA;
 /******/ 	
 /******/ 	__webpack_require__.C = installChunk;
 /******/ 	
-/******/ 	// no analyzable chunk import
-/******/ 	
 /******/ 	// no on chunks loaded
 /******/ 	// no HMR
 /******/ 	
@@ -269,8 +267,6 @@ exports[`ConfigCacheTestCases html script-src-mixed exported tests should chain 
 /******/ 	// no preloaded
 /******/ 	
 /******/ 	__webpack_require__.C = installChunk;
-/******/ 	
-/******/ 	// no analyzable chunk import
 /******/ 	
 /******/ 	// no on chunks loaded
 /******/ 	// no HMR

--- a/test/configCases/html/script-src-mixed/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/script-src-mixed/__snapshots__/ConfigTest.snap
@@ -137,8 +137,6 @@ globalThis.__moduleA = moduleA;
 /******/ 	
 /******/ 	__webpack_require__.C = installChunk;
 /******/ 	
-/******/ 	// no analyzable chunk import
-/******/ 	
 /******/ 	// no on chunks loaded
 /******/ 	// no HMR
 /******/ 	
@@ -269,8 +267,6 @@ exports[`ConfigTestCases html script-src-mixed exported tests should chain multi
 /******/ 	// no preloaded
 /******/ 	
 /******/ 	__webpack_require__.C = installChunk;
-/******/ 	
-/******/ 	// no analyzable chunk import
 /******/ 	
 /******/ 	// no on chunks loaded
 /******/ 	// no HMR

--- a/test/configCases/html/script-src/__snapshots__/ConfigCacheTest.snap
+++ b/test/configCases/html/script-src/__snapshots__/ConfigCacheTest.snap
@@ -107,8 +107,6 @@ module.exports = \\"first entry\\";
 /******/ 	
 /******/ 	__webpack_require__.C = installChunk;
 /******/ 	
-/******/ 	// no analyzable chunk import
-/******/ 	
 /******/ 	// no on chunks loaded
 /******/ 	// no HMR
 /******/ 	

--- a/test/configCases/html/script-src/__snapshots__/ConfigTest.snap
+++ b/test/configCases/html/script-src/__snapshots__/ConfigTest.snap
@@ -107,8 +107,6 @@ module.exports = \\"first entry\\";
 /******/ 	
 /******/ 	__webpack_require__.C = installChunk;
 /******/ 	
-/******/ 	// no analyzable chunk import
-/******/ 	
 /******/ 	// no on chunks loaded
 /******/ 	// no HMR
 /******/ 	

--- a/test/configCases/worker/worker-analyzable-import/index.js
+++ b/test/configCases/worker/worker-analyzable-import/index.js
@@ -26,6 +26,6 @@ it("should emit the analyzable literal inside the worker chunk", () => {
 		"utf8"
 	);
 
-	expect(source).toContain(`${"__webpack_require__"}.ei("lazy_js"`);
+	expect(source).toContain(`${"chunkImports"} = {`);
 	expect(source).toContain('"./lazy_js.mjs")');
 });

--- a/test/helpers/analyzableConformance.js
+++ b/test/helpers/analyzableConformance.js
@@ -8,6 +8,7 @@ const path = require("path");
 const acorn = require("acorn");
 const ConcatenatedModule = require("../../lib/optimize/ConcatenatedModule");
 
+/** @import Chunk from "../../lib/Chunk" */
 /** @import Compilation from "../../lib/Compilation" */
 /** @import Module from "../../lib/Module" */
 
@@ -215,9 +216,11 @@ const hidesEverySpecifier = (compilation) => {
 };
 
 /**
- * Whether the build said why nothing names this chunk. A reason is recorded on
- * the module that wrote the reference, so the modules to ask are the ones whose
- * request created the chunk, plus the runtime modules shipped inside it.
+ * Whether the build said why nothing names this chunk. A reason is recorded on the
+ * module that wrote the reference: the modules whose request created the chunk, the
+ * runtime modules shipped inside it, and — since a chunk loaded on demand is named
+ * by the chunk loader rather than at the import site — those of every runtime
+ * reaching it.
  * @param {Compilation} compilation the compilation that emitted it
  * @param {string} file the emitted javascript file
  * @returns {boolean} true where a reason stands behind it
@@ -241,15 +244,30 @@ const isExplained = (compilation, file) => {
 			runtimeTemplate.analyzableBailoutsOf(generated).length > 0
 		);
 	};
-	for (const chunk of compilation.chunks) {
-		if (!chunk.files.has(file)) continue;
+	/**
+	 * @param {Chunk} chunk the chunk to read the runtime modules of
+	 * @returns {boolean} true where one of them recorded a reason
+	 */
+	const runtimeRecorded = (chunk) => {
 		for (const module of chunkGraph.getChunkRuntimeModulesIterable(chunk)) {
 			if (recorded(module)) return true;
 		}
+		return false;
+	};
+	for (const chunk of compilation.chunks) {
+		if (!chunk.files.has(file)) continue;
+		if (runtimeRecorded(chunk)) return true;
 		for (const group of chunk.groupsIterable) {
 			for (const origin of group.origins) {
 				if (origin.module && recorded(origin.module)) return true;
 			}
+		}
+		// The loader that would have named it lives in another chunk, so its reason
+		// does too — one per runtime rather than one per import site.
+		for (const other of compilation.chunks) {
+			if (other === chunk || !other.hasRuntime()) continue;
+			if (!other.getAllReferencedChunks().has(chunk)) continue;
+			if (runtimeRecorded(other)) return true;
 		}
 	}
 	return false;

--- a/test/hotCases/esm-output/analyzable-import/index.js
+++ b/test/hotCases/esm-output/analyzable-import/index.js
@@ -16,7 +16,7 @@ it("should emit the analyzable import under HMR and still apply updates", (done)
 			// Needles are built at runtime so they are not source string literals here.
 			const bundle = getFile("main.mjs");
 			const require_ = "__webpack_require__";
-			expect(bundle).toContain(`${require_}.ei(`);
+			expect(bundle).toContain(`${"chunkImports"} = {`);
 			expect(bundle).toContain('import("./async-module_js.mjs")');
 			// The hot runtime registers its handler on the map and force-loads through
 			// the others by bare chunk id, so both survive an all-analyzable graph.

--- a/test/hotCases/lazy-compilation/analyzable-import/index.js
+++ b/test/hotCases/lazy-compilation/analyzable-import/index.js
@@ -12,7 +12,7 @@ const proxyChunks = () => {
 
 import.meta.webpackHot.accept(["./module.js"]);
 
-it("should bake the analyzable import into the lazy compilation proxy", (done) => {
+it("should load a chunk the lazy compilation proxy creates after the build", (done) => {
 	expect(message).toBe("original");
 
 	const promise = import("./lazy-module");
@@ -25,15 +25,12 @@ it("should bake the analyzable import into the lazy compilation proxy", (done) =
 
 					// Needles are built at runtime so they are not source string literals here.
 					const require_ = "__webpack_require__";
-					// The proxy only names a chunk once the module is activated, so the
-					// import lands in the update it is rebuilt into.
+					// The loader's map is fixed when the build runs, so a chunk the proxy
+					// creates after it is loaded by id through the runtime form instead.
 					const chunks = proxyChunks();
 					expect(
-						chunks.filter((chunk) => chunk.includes(`${require_}.ei(`))
-					).not.toHaveLength(0);
-					expect(
 						chunks.filter((chunk) => chunk.includes(`${require_}.e(`))
-					).toHaveLength(0);
+					).not.toHaveLength(0);
 					done();
 				})
 				.catch(done);

--- a/test/statsCases/analyzable-esm-fallbacks/__snapshots__/StatsTest.snap
+++ b/test/statsCases/analyzable-esm-fallbacks/__snapshots__/StatsTest.snap
@@ -4,7 +4,7 @@ exports[`StatsTestCases analyzable-esm-fallbacks should print correct stats for 
 "analyzable:
   asset main.mjs X KiB [emitted] [javascript module] (name: main)
   asset async_js.mjs X bytes [emitted] [javascript module]
-  runtime modules X KiB 4 modules
+  runtime modules X KiB 5 modules
   cacheable modules X bytes
     ./index.js X bytes [built] [code generated]
     ./async.js X bytes [built] [code generated]
@@ -14,7 +14,7 @@ shared-chunk:
   asset a.mjs X KiB [emitted] [javascript module] (name: a)
   asset b.mjs X KiB [emitted] [javascript module] (name: b)
   asset async_js.mjs X bytes [emitted] [javascript module]
-  runtime modules X KiB 8 modules
+  runtime modules X KiB 10 modules
   cacheable modules X bytes
     ./a.js X bytes [built] [code generated]
     ./b.js X bytes [built] [code generated]
@@ -35,7 +35,7 @@ prefetch:
 bare-public-path:
   asset main.mjs X KiB [emitted] [javascript module] (name: main)
   asset async_js.mjs X bytes [emitted] [javascript module]
-  runtime modules X KiB 4 modules
+  runtime modules X KiB 5 modules
   cacheable modules X bytes
     ./index.js X bytes [built] [code generated]
     ./async.js X bytes [built] [code generated]
@@ -44,7 +44,7 @@ bare-public-path:
 fetch-priority:
   asset main.mjs X KiB [emitted] [javascript module] (name: main)
   asset async_js.mjs X bytes [emitted] [javascript module]
-  runtime modules X KiB 4 modules
+  runtime modules X KiB 5 modules
   cacheable modules X bytes
     ./index-fetch-priority.js X bytes [built] [code generated]
     ./async.js X bytes [built] [code generated]
@@ -62,7 +62,7 @@ hmr:
 templated-public-path:
   asset main.mjs X KiB [emitted] [javascript module] (name: main)
   asset async_js.mjs X bytes [emitted] [javascript module]
-  runtime modules X KiB 4 modules
+  runtime modules X KiB 5 modules
   cacheable modules X bytes
     ./index.js X bytes [built] [code generated]
     ./async.js X bytes [built] [code generated]
@@ -71,7 +71,7 @@ templated-public-path:
 content-hash:
   asset main.XXXXXXXXXXXXXXXXXXXX.mjs X KiB [emitted] [immutable] [javascript module] (name: main)
   asset async_js.XXXXXXXXXXXXXXXXXXXX.mjs X bytes [emitted] [immutable] [javascript module]
-  runtime modules X KiB 4 modules
+  runtime modules X KiB 5 modules
   cacheable modules X bytes
     ./index.js X bytes [built] [code generated]
     ./async.js X bytes [built] [code generated]
@@ -83,7 +83,7 @@ shared-depths:
     asset flat.XXXXXXXXXXXXXXXXXXXX.mjs X KiB [emitted] [immutable] [javascript module] (name: flat)
   asset main.mjs X KiB [emitted] [javascript module] (name: main)
   asset async_js.mjs X bytes [emitted] [javascript module]
-  runtime modules X KiB 4 modules
+  runtime modules X KiB 5 modules
   cacheable modules X bytes
     ./index-depths.js X bytes [built] [code generated]
     ./depths-flat.js X bytes [built] [code generated]
@@ -143,7 +143,7 @@ environment-module:
   asset main.mjs X KiB [emitted] [javascript module] (name: main)
   asset async_js.mjs X bytes [emitted] [javascript module]
   asset XXXXXXXXXXXXXXXXXXXX.txt X bytes [emitted] [immutable] [from: asset.txt] (auxiliary name: main)
-  runtime modules X KiB 4 modules
+  runtime modules X KiB 5 modules
   cacheable modules X bytes (javascript) X bytes (asset)
     ./index-asset.js X bytes [built] [code generated]
     ./asset.txt X bytes [built] [code generated]
@@ -154,7 +154,7 @@ circular:
   asset main.mjs X KiB [emitted] [javascript module] (name: main)
   asset a-cycle_js.XXXXXXXXXXXXXXXXXXXX.mjs X bytes [emitted] [immutable] [javascript module]
   asset b-cycle_js.XXXXXXXXXXXXXXXXXXXX.mjs X bytes [emitted] [immutable] [javascript module]
-  runtime modules X KiB 4 modules
+  runtime modules X KiB 5 modules
   cacheable modules X bytes
     ./index-cycle.js X bytes [built] [code generated]
     ./a-cycle.js X bytes [built] [code generated]
@@ -165,7 +165,7 @@ base-uri:
   asset main.mjs X KiB [emitted] [javascript module] (name: main)
   asset async_js.mjs X bytes [emitted] [javascript module]
   asset XXXXXXXXXXXXXXXXXXXX.txt X bytes [emitted] [immutable] [from: asset.txt] (auxiliary name: main)
-  runtime modules X KiB 4 modules
+  runtime modules X KiB 5 modules
   cacheable modules X bytes (javascript) X bytes (asset)
     ./index-asset.js X bytes [built] [code generated]
     ./asset.txt X bytes [built] [code generated]
@@ -281,7 +281,7 @@ served-both-ways:
   asset XXXXXXXXXXXXXXXXXXXX.txt X bytes [emitted] [immutable] [from: asset.txt]
   Entrypoint main X KiB (X bytes) = both_js.mjs X bytes main.mjs X KiB 1 auxiliary asset
   Entrypoint side X KiB = side.mjs
-  runtime modules X KiB 12 modules
+  runtime modules X KiB 13 modules
   cacheable modules X bytes (javascript) X bytes (asset)
     ./index-both.js X bytes [built] [code generated]
     ./side-both.js X bytes [built] [code generated]

--- a/test/statsCases/analyzable-esm-fallbacks/test.config.js
+++ b/test/statsCases/analyzable-esm-fallbacks/test.config.js
@@ -3,11 +3,11 @@
 const fs = require("fs");
 const path = require("path");
 
-const HELPER = "__webpack_require__.ei";
+const IMPORT_MAP = "chunkImports = {";
 const BAILOUT = "Analyzable ESM bailout:";
 
-// Per case: which emitted file to inspect, and whether it emits the `.ei` helper
-// ("analyzable") or keeps the runtime form and names its reason ("fallback").
+// Per case: which emitted file to inspect, and whether the loader holds a map of
+// literal specifiers ("analyzable") or names why it does not ("fallback").
 const CASES = {
 	analyzable: { file: "main.mjs", expect: "analyzable" },
 	"public-path-override": {
@@ -15,8 +15,8 @@ const CASES = {
 		expect: "fallback",
 		bailout: "__webpack_public_path__ is reassigned"
 	},
-	// `fetchPriority` is unsupported for ESM output, so it must not degrade the
-	// output — the analyzable form is still emitted (documented limitation).
+	// A native `import()` cannot carry `fetchPriority`, but the hint still reaches
+	// `ensureChunk`, and the chunk is named in the loader's map either way.
 	"fetch-priority": { file: "main.mjs", expect: "analyzable" },
 	// The entry is named by its own content with nothing to repair that name after a
 	// rewrite, so what the stand-in resolves to is folded into its hash instead.
@@ -27,13 +27,12 @@ const CASES = {
 	"bare-public-path": { file: "main.mjs", expect: "analyzable" },
 	"shared-chunk": { file: "a.mjs", expect: "analyzable" },
 	prefetch: { file: "main.mjs", expect: "analyzable" },
-	// The hot require wraps `.ei` like `.e`, so an update still blocks on a chunk
-	// load in flight and HMR does not force the runtime form.
+	// A hot update re-ships the map only when its own text moves, so HMR does not
+	// force the runtime form.
 	hmr: { file: "main.mjs", expect: "analyzable" },
-	// Two depths need a per-asset stand-in for the `../` path, and the chunks it lands in
-	// are named by their content — the depth is read off the template with the hashes
-	// neutralized, so it folds into those names like any other part.
-	"shared-depths": { file: /^flat\./, expect: "analyzable" },
+	// Two depths reach the same chunk, which the loader names once from where it sits
+	// rather than once per depth — so the map is in the entry, not in either depth.
+	"shared-depths": { file: "main.mjs", expect: "analyzable" },
 	"eval-devtool": {
 		file: "main.mjs",
 		expect: "fallback",
@@ -159,16 +158,16 @@ module.exports = {
 			}
 			if (testCase.lacks) expect(output).not.toContain(testCase.lacks);
 			if (testCase.expect === "analyzable") {
-				expect(output).toContain(HELPER);
+				expect(output).toContain(IMPORT_MAP);
 				expect(bailouts).toEqual([]);
 			} else if (testCase.expect === "partial") {
 				// A limitation that stops some references and not others leaves the rest
-				// baked, so the helper is still the right thing to find.
-				expect(output).toContain(HELPER);
+				// named, so the map is still the right thing to find.
+				expect(output).toContain(IMPORT_MAP);
 				expect(bailouts.join("\n")).toContain(testCase.bailout);
 			} else {
-				// A limitation must not emit extra runtime — the `.ei` helper stays out.
-				expect(output).not.toContain(HELPER);
+				// A limitation keeps every name out of the loader, so it holds no map.
+				expect(output).not.toContain(IMPORT_MAP);
 				expect(bailouts.join("\n")).toContain(testCase.bailout);
 			}
 		}

--- a/test/statsCases/analyzable-esm-fallbacks/webpack.config.js
+++ b/test/statsCases/analyzable-esm-fallbacks/webpack.config.js
@@ -52,7 +52,7 @@ const base = (name, extra = {}) => ({
 
 /** @type {import("../../../").Configuration[]} */
 module.exports = [
-	// Analyzable: emits `import("./async.mjs")` + the `.ei` helper.
+	// Analyzable: the loader holds `import("./async.mjs")`, read by chunk id.
 	base("analyzable"),
 	// Also analyzable: a chunk in several groups still dedupes through `.ei`'s
 	// `installedChunks` bookkeeping, so sharing does not need the runtime form.
@@ -90,7 +90,7 @@ module.exports = [
 		entry: "./index-depths",
 		plugins: [nameConsumersByContent(["flat", "nested/deep"])]
 	}),
-	// Every case below must fall back with no `.ei` emitted.
+	// Every case below must fall back, with the loader holding no map of names.
 	base("public-path-override", { entry: "./index-public-path-override" }),
 	// `import.meta` does not parse inside the `eval()` this devtool wraps a module in.
 	base("eval-devtool", {

--- a/test/statsCases/output-module/__snapshots__/StatsTest.snap
+++ b/test/statsCases/output-module/__snapshots__/StatsTest.snap
@@ -3,7 +3,7 @@
 exports[`StatsTestCases output-module should print correct stats for output-module 1`] = `
 "asset main.mjs X KiB [emitted] [javascript module] (name: main)
 asset 936.mjs X bytes [emitted] [javascript module]
-runtime modules X KiB 3 modules
+runtime modules X KiB 4 modules
 orphan modules X bytes [orphan] 1 module
 cacheable modules X bytes
   ./index.js + 1 modules X bytes [built] [code generated]

--- a/test/watchCases/chunks/esm-async-chunks-hmr/0/index.js
+++ b/test/watchCases/chunks/esm-async-chunks-hmr/0/index.js
@@ -31,9 +31,9 @@ it("should work where an ESM entryChunk depends on the runtimeChunk", async func
 		expect(mainChunk.hash).not.toBe(STATE.mainChunkHash);
 		// async dynamic1Chunk need to be updated
 		expect(dynamic1Chunk.hash).not.toBe(STATE.dynamic1ChunkHash);
-		// The entry imports each async chunk by name itself, so nothing in the runtime
-		// chunk names one and it needn't be updated.
-		expect(runtimeChunk.hash).toBe(STATE.runtimeChunkHash);
+		// The loader names each async chunk, so the runtime chunk follows their hashes
+		// and the entry, which imports it by name, follows in turn.
+		expect(runtimeChunk.hash).not.toBe(STATE.runtimeChunkHash);
 	}
 	done()
 });

--- a/types.d.ts
+++ b/types.d.ts
@@ -26586,6 +26586,16 @@ declare abstract class RuntimeTemplate {
 	reportChunkImportBailout(chunk: Chunk, chunkGraph: ChunkGraph): void;
 
 	/**
+	 * Whether the loader still needs to build a url from a chunk id: a chunk carrying
+	 * a runtime of its own is reached by a static import and so is never named in the
+	 * map, and only a runtime that can reach one has to keep the fallback.
+	 */
+	chunkImportsNeedRuntimeUrl(
+		runtimeChunk: Chunk,
+		chunkGraph: ChunkGraph
+	): boolean;
+
+	/**
 	 * A literal `import()` specifier for every javascript chunk a runtime loads on
 	 * demand, keyed by chunk id, or `null` when one of them cannot be named here. The
 	 * map is written into the runtime chunk rather than at each import site, so a

--- a/types.d.ts
+++ b/types.d.ts
@@ -26522,24 +26522,10 @@ declare abstract class RuntimeTemplate {
 		 */
 		runtimeRequirements: Set<string>;
 		/**
-		 * the module the `import()` is emitted into
+		 * the module the `import()` is emitted into, to report against
 		 */
 		originModule?: Module;
 	}): string;
-
-	/**
-	 * For ESM module output, load a single statically-named chunk through the
-	 * `analyzableChunkImport` helper — a literal `import("./chunk.js")` other bundlers
-	 * and webpack itself can follow, wrapped to keep `ensureChunk` timing and deduplication.
-	 * Returns `null` to fall back to the runtime `ensureChunk` form.
-	 */
-	analyzableChunkImport(
-		chunk: Chunk,
-		comment: string,
-		runtimeRequirements: Set<string>,
-		originModule: undefined | Module,
-		chunkGraph: ChunkGraph
-	): null | string;
 
 	/**
 	 * The `../` path from a chunk's own asset back to the output root. Hashes are
@@ -26586,6 +26572,26 @@ declare abstract class RuntimeTemplate {
 	 * them and the plugin declaring what it needs ask this, so the two always agree.
 	 */
 	analyzableChunkScriptUrls(
+		runtimeChunk: Chunk,
+		chunkGraph: ChunkGraph,
+		runtimeRequirements: ReadonlySet<string>,
+		consumingModule?: Module
+	): null | Map<ChunkId, string>;
+
+	/**
+	 * Records that this runtime reads its chunks some way other than a native
+	 * `import()`, so no literal can name what it loads. Recorded on the entries that
+	 * chose it, which is where the setting behind it lives.
+	 */
+	reportChunkImportBailout(chunk: Chunk, chunkGraph: ChunkGraph): void;
+
+	/**
+	 * A literal `import()` specifier for every javascript chunk a runtime loads on
+	 * demand, keyed by chunk id, or `null` when one of them cannot be named here. The
+	 * map is written into the runtime chunk rather than at each import site, so a
+	 * hashed chunk name reaches no module that imports it.
+	 */
+	analyzableChunkImports(
 		runtimeChunk: Chunk,
 		chunkGraph: ChunkGraph,
 		runtimeRequirements: ReadonlySet<string>,
@@ -30556,7 +30562,6 @@ declare namespace exports {
 	export namespace RuntimeGlobals {
 		export let amdDefine: "__webpack_require__.amdD";
 		export let amdOptions: "__webpack_require__.amdO";
-		export let analyzableChunkImport: "__webpack_require__.ei";
 		export let asyncModule: "__webpack_require__.a";
 		export let asyncModuleDoneSymbol: "__webpack_require__.aD";
 		export let asyncModuleExportSymbol: "__webpack_require__.aE";

--- a/types.d.ts
+++ b/types.d.ts
@@ -26586,9 +26586,9 @@ declare abstract class RuntimeTemplate {
 	reportChunkImportBailout(chunk: Chunk, chunkGraph: ChunkGraph): void;
 
 	/**
-	 * Whether the loader still needs to build a url from a chunk id: a chunk carrying
-	 * a runtime of its own is reached by a static import and so is never named in the
-	 * map, and only a runtime that can reach one has to keep the fallback.
+	 * Whether the loader still needs to build a url from a chunk id, which is the case
+	 * for a chunk it can be asked for that `analyzableChunkImports` leaves unnamed: one
+	 * carrying a runtime of its own, or one a second entrypoint has at startup.
 	 */
 	chunkImportsNeedRuntimeUrl(
 		runtimeChunk: Chunk,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Since 5.110 ESM output baked a literal `import("./chunk.<contenthash>.js")` at every dynamic import site, so an importing module's own hash followed the imported chunk's and a change to one lazy route invalidated every chunk up to the initial wave. The ESM chunk loader now holds those specifiers itself, keyed by chunk id, and call sites go back to `__webpack_require__.e(id)` — the output stays followable by a foreign bundler or a preload scanner, but no importing module carries a chunk hash. Closes #22056.

On the reporter's shape (10 initial chunks, `runtimeChunk: "single"`, `[contenthash]`), one attribute changed in a component reachable only through a lazy route: the chunk holding the route imports stops invalidating, so a returning user refetches 57.3 KiB gz (37%) instead of 88.2 KiB gz (57%). The initial wave itself moves by +312 raw / +99 gzip bytes (+0.06%), and `yarn test:size` reports `Changed, same case source` at +3.25 KiB gzip over 290 assets — `ensure chunk` and the js handler return per runtime, while the per-site specifiers collapse to one map entry per chunk. So this is a caching fix, not a size win.

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — the `configCases/analyzable/` suite is updated throughout, plus `worker/`, the two `hotCases/*/analyzable-import` cases and `statsCases/analyzable-esm-fallbacks`. Cases whose subject was a cross-chunk hash cycle or a per-depth specifier now pin that neither shape is reachable.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No, for configuration. The emitted runtime changes shape and `__webpack_require__.ei` is gone; anything reading it would need updating, but it shipped only in 5.110–5.110.3.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

webpack/webpack.js.org#8387 updates `output.chunkFilename` to say where an ESM build names its chunks, and drops the `performance.analyzableBailouts` row for a reason no longer reported.

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Claude Code wrote this change and its tests under my direction and review. It was also used to measure the before/after invalidation and size numbers quoted above, and to verify no two builds ship different bytes under one `[contenthash]`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * JavaScript module output now centralizes dynamically loaded chunk names in the runtime loader, improving consistency across shared, nested, and circular chunks.
  * Generated imports can use direct module specifiers where supported, while retaining runtime loading for URLs, HMR, and other fallback scenarios.
  * Fetch-priority hints and public-path configurations are better supported for generated dynamic imports.

* **Bug Fixes**
  * Improved chunk naming and content-hash stability, reducing stale references.
  * Multi-chunk loading no longer passes unintended array indexes as fetch priorities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->