### PR TITLE
fix(parser): wrap spec namespaces before assimilating then exports

### DIFF
--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -2145,15 +2145,22 @@ class RuntimeTemplate {
 		} else {
 			let fakeType = 16;
 			switch (exportsType) {
-				case "namespace":
-					if (header) {
-						const rawModule = this.moduleRaw({
+				case "namespace": {
+					const specNamespace = usesSpecNamespaceObject(module);
+					const asyncModule = chunkGraph.moduleGraph.isAsync(module);
+					if (header || (specNamespace && !asyncModule)) {
+						let rawModule = this.moduleRaw({
 							module,
 							chunkGraph,
 							request,
 							weak,
 							runtimeRequirements
 						});
+						if (specNamespace && !asyncModule) {
+							runtimeRequirements.add(RuntimeGlobals.specNamespaceObject);
+							// Wrap before promise resolution assimilates an exported `then`.
+							rawModule = `${RuntimeGlobals.specNamespaceObject}(${rawModule})`;
+						}
 						appending = `.then(${this.basicFunction(
 							"",
 							`${header}return ${rawModule};`
@@ -2166,12 +2173,13 @@ class RuntimeTemplate {
 						)})`;
 					}
 
-					if (usesSpecNamespaceObject(module)) {
+					if (specNamespace && asyncModule) {
 						runtimeRequirements.add(RuntimeGlobals.specNamespaceObject);
 						appending += `.then(${RuntimeGlobals.specNamespaceObject})`;
 					}
 
 					break;
+				}
 				case "dynamic":
 					fakeType |= 4;
 				/* fall through */

--- a/test/configCases/spec-namespace-objects/then-export/async.js
+++ b/test/configCases/spec-namespace-objects/then-export/async.js
@@ -1,0 +1,3 @@
+await Promise.resolve();
+
+export const then = 123;

--- a/test/configCases/spec-namespace-objects/then-export/index.js
+++ b/test/configCases/spec-namespace-objects/then-export/index.js
@@ -1,0 +1,28 @@
+import * as namespace from "./module.js";
+import * as asyncNamespace from "./async.js";
+
+it("should await async modules before wrapping their namespace", async () => {
+	expect(await import("./async.js")).toBe(asyncNamespace);
+	expect(await import(/* webpackMode: "weak" */ "./async.js")).toBe(
+		asyncNamespace
+	);
+	expect(asyncNamespace.then).toBe(123);
+});
+
+it("should assimilate an exported then using the spec namespace", async () => {
+	const imports = [
+		() => import("./module.js"),
+		() => import(/* webpackMode: "eager" */ "./module.js"),
+		() => import(/* webpackMode: "weak" */ "./module.js")
+	];
+	const object = { answer: 42 };
+	for (const load of imports) {
+		for (const value of [123, null, undefined, object]) {
+			namespace.setResult(value);
+			const calls = namespace.calls;
+			expect(await load()).toBe(value);
+			expect(namespace.calls).toBe(calls + 1);
+			expect(namespace.receiver).toBe(namespace);
+		}
+	}
+});

--- a/test/configCases/spec-namespace-objects/then-export/module.js
+++ b/test/configCases/spec-namespace-objects/then-export/module.js
@@ -1,0 +1,21 @@
+export let calls = 0;
+export let receiver;
+export let result = 123;
+
+/**
+ * @param {unknown} value the next import result
+ * @returns {void}
+ */
+export function setResult(value) {
+	result = value;
+}
+
+/**
+ * @param {(value: unknown) => void} resolve the import resolution callback
+ * @returns {void}
+ */
+export function then(resolve) {
+	calls++;
+	receiver = this;
+	resolve(result);
+}

--- a/test/configCases/spec-namespace-objects/then-export/webpack.config.js
+++ b/test/configCases/spec-namespace-objects/then-export/webpack.config.js
@@ -1,0 +1,9 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [true, false].map((arrowFunction) => ({
+	output: { environment: { arrowFunction } },
+	module: {
+		parser: { javascript: { specNamespaceObject: true } }
+	}
+}));

--- a/test/configCases/spec-namespace-objects/then-export/webpack.config.js
+++ b/test/configCases/spec-namespace-objects/then-export/webpack.config.js
@@ -2,7 +2,10 @@
 
 /** @type {import("../../../../").Configuration[]} */
 module.exports = [true, false].map((arrowFunction) => ({
-	output: { environment: { arrowFunction } },
+	output: {
+		library: { type: "commonjs2" },
+		environment: { arrowFunction }
+	},
 	module: {
 		parser: { javascript: { specNamespaceObject: true } }
 	}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

With `specNamespaceObject` enabled, dynamically importing a synchronous module that exports `then(resolve) { resolve(123); }` rejects with `Invalid value used as weak map key` instead of resolving to `123`. Wrap its exports before promise assimilation so `then` receives the spec namespace as `this` and its resolved value is preserved; refs #22049.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `test/configCases/spec-namespace-objects/then-export/` covers normal, eager and weak imports, primitive and object results, receiver identity, arrow-function settings, and an async-module namespace control. The regression failed before the fix; all 82 selected namespace tests passed across `ConfigTestCases` and `ConfigCacheTestCases`. Formatting, comment-length and spelling checks passed; local ESLint failed loading its configuration, and TypeScript reported errors involving parser typings, `eslint-scope` types and missing `@mdn/browser-compat-data`.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Codex was used to investigate and reproduce the bug, implement the fix, add regression tests, run validation, and draft this description.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed namespace handling for modules that export a `then` property, preventing non-async modules from being incorrectly treated as thenables.
  - Preserved correct asynchronous behavior by ensuring async modules are fully resolved before their namespace is wrapped.
  - Improved consistency across default, eager, weak, and dynamic import scenarios.
- **Tests**
  - Added coverage for `then` exports, async modules, namespace identity, and multiple resolution values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->