### PR TITLE
fix(esm): escape external requests in star reexports

### DIFF
--- a/.changeset/013-escape-esm-reexport-requests.md
+++ b/.changeset/013-escape-esm-reexport-requests.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-Escape external module requests in ESM library star reexports.
+Escape external requests in generated ESM imports and star reexports.

--- a/.changeset/013-escape-esm-reexport-requests.md
+++ b/.changeset/013-escape-esm-reexport-requests.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Escape external module requests in ESM library star reexports.

--- a/lib/ExternalModule.js
+++ b/lib/ExternalModule.js
@@ -29,6 +29,7 @@ const { coreModules } = require("./node/nodeBuiltins");
 const createHash = require("./util/createHash");
 const createHooksRegistry = require("./util/createHooksRegistry");
 const extractUrlAndGlobal = require("./util/extractUrlAndGlobal");
+const { toJsStringLiteral } = require("./util/identifier");
 const makeSerializable = require("./util/makeSerializable");
 const memoize = require("./util/memoize");
 const { propertyAccess } = require("./util/property");
@@ -518,18 +519,18 @@ class ModuleExternalInitFragment extends InitFragment {
 		if (ImportPhaseUtils.isSource(phase) && imported === true) {
 			// There is no `import source * as ns` form: the source phase binds one
 			// identifier, so it stands in for the namespace the other branches build.
-			content = `import source ${identifier} from ${JSON.stringify(
+			content = `import source ${identifier} from ${toJsStringLiteral(
 				request
 			)}${attributes};\n`;
 		} else if (imported === true) {
 			// namespace
 			const phaseKeyword = ImportPhaseUtils.isDefer(phase) ? "defer " : "";
-			content = `import ${phaseKeyword}* as ${identifier} from ${JSON.stringify(
+			content = `import ${phaseKeyword}* as ${identifier} from ${toJsStringLiteral(
 				request
 			)}${attributes};\n`;
 		} else if (imported.length === 0) {
 			// just import, no use
-			content = `import ${JSON.stringify(request)}${attributes};\n`;
+			content = `import ${toJsStringLiteral(request)}${attributes};\n`;
 		} else if (
 			ImportPhaseUtils.isSource(phase) &&
 			imported.length === 1 &&
@@ -537,7 +538,7 @@ class ModuleExternalInitFragment extends InitFragment {
 		) {
 			// `import source x from "…"` — the source-phase form binds the source
 			// object directly to a single identifier (no namespace, no destructuring).
-			content = `import source ${imported[0][1]} from ${JSON.stringify(
+			content = `import source ${imported[0][1]} from ${toJsStringLiteral(
 				request
 			)}${attributes};\n`;
 		} else {
@@ -548,7 +549,7 @@ class ModuleExternalInitFragment extends InitFragment {
 					}
 					return name;
 				})
-				.join(", ")} } from ${JSON.stringify(request)}${attributes};\n`;
+				.join(", ")} } from ${toJsStringLiteral(request)}${attributes};\n`;
 		}
 		return content;
 	}

--- a/lib/library/ModuleLibraryPlugin.js
+++ b/lib/library/ModuleLibraryPlugin.js
@@ -474,7 +474,7 @@ class ModuleLibraryPlugin extends AbstractLibraryPlugin {
 		resolveDynamicStarReexport(module, false);
 
 		for (const request of moduleRequests) {
-			result.add(`export * from "${request}";\n`);
+			result.add(`export * from ${JSON.stringify(request)};\n`);
 		}
 
 		for (const [origin, used] of unknownProvidedExports) {

--- a/lib/library/ModuleLibraryPlugin.js
+++ b/lib/library/ModuleLibraryPlugin.js
@@ -17,6 +17,7 @@ const HarmonyExportSpecifierDependency = require("../dependencies/HarmonyExportS
 const JavascriptModulesPlugin = require("../javascript/JavascriptModulesPlugin");
 const ConcatenatedModule = require("../optimize/ConcatenatedModule");
 const { InlinedUsedName } = require("../optimize/InlineExports");
+const { toJsStringLiteral } = require("../util/identifier");
 const {
 	RESERVED_IDENTIFIER,
 	SAFE_IDENTIFIER,
@@ -474,7 +475,7 @@ class ModuleLibraryPlugin extends AbstractLibraryPlugin {
 		resolveDynamicStarReexport(module, false);
 
 		for (const request of moduleRequests) {
-			result.add(`export * from ${JSON.stringify(request)};\n`);
+			result.add(`export * from ${toJsStringLiteral(request)};\n`);
 		}
 
 		for (const [origin, used] of unknownProvidedExports) {

--- a/test/configCases/library/module-reexport-escaped-request/index.js
+++ b/test/configCases/library/module-reexport-escaped-request/index.js
@@ -8,15 +8,3 @@ it("should preserve escaped external requests in native star reexports", () => {
 	expect(library.paragraph).toBe(5);
 	expect(library.plain).toBe(6);
 });
-
-it("should escape line separators in emitted module specifiers", () => {
-	const fs = __non_webpack_require__("fs");
-	const source = fs.readFileSync(
-		__filename.replace(/main(\d+)\.mjs$/, "library$1.mjs"),
-		"utf-8"
-	);
-	expect(source).toMatch(/import\s*\*\s*as\s+\S+\s*from\s*"separator\\u2028module"/);
-	expect(source).toMatch(/import\s*\*\s*as\s+\S+\s*from\s*"paragraph\\u2029module"/);
-	expect(source).toMatch(/export\s*\*\s*from\s*"separator\\u2028module"/);
-	expect(source).toMatch(/export\s*\*\s*from\s*"paragraph\\u2029module"/);
-});

--- a/test/configCases/library/module-reexport-escaped-request/index.js
+++ b/test/configCases/library/module-reexport-escaped-request/index.js
@@ -4,5 +4,19 @@ it("should preserve escaped external requests in native star reexports", () => {
 	expect(library.quoted).toBe(1);
 	expect(library.backslash).toBe(2);
 	expect(library.newline).toBe(3);
-	expect(library.plain).toBe(4);
+	expect(library.separator).toBe(4);
+	expect(library.paragraph).toBe(5);
+	expect(library.plain).toBe(6);
+});
+
+it("should escape line separators in emitted module specifiers", () => {
+	const fs = __non_webpack_require__("fs");
+	const source = fs.readFileSync(
+		__filename.replace(/main(\d+)\.mjs$/, "library$1.mjs"),
+		"utf-8"
+	);
+	expect(source).toMatch(/import\s*\*\s*as\s+\S+\s*from\s*"separator\\u2028module"/);
+	expect(source).toMatch(/import\s*\*\s*as\s+\S+\s*from\s*"paragraph\\u2029module"/);
+	expect(source).toMatch(/export\s*\*\s*from\s*"separator\\u2028module"/);
+	expect(source).toMatch(/export\s*\*\s*from\s*"paragraph\\u2029module"/);
 });

--- a/test/configCases/library/module-reexport-escaped-request/index.js
+++ b/test/configCases/library/module-reexport-escaped-request/index.js
@@ -1,0 +1,8 @@
+import * as library from "./library.mjs";
+
+it("should preserve escaped external requests in native star reexports", () => {
+	expect(library.quoted).toBe(1);
+	expect(library.backslash).toBe(2);
+	expect(library.newline).toBe(3);
+	expect(library.plain).toBe(4);
+});

--- a/test/configCases/library/module-reexport-escaped-request/library.js
+++ b/test/configCases/library/module-reexport-escaped-request/library.js
@@ -1,4 +1,6 @@
 export * from 'quoted"module';
 export * from "backslash\\module";
 export * from "line\nmodule";
+export * from "separator\u2028module";
+export * from "paragraph\u2029module";
 export * from "plain-module";

--- a/test/configCases/library/module-reexport-escaped-request/library.js
+++ b/test/configCases/library/module-reexport-escaped-request/library.js
@@ -1,0 +1,4 @@
+export * from 'quoted"module';
+export * from "backslash\\module";
+export * from "line\nmodule";
+export * from "plain-module";

--- a/test/configCases/library/module-reexport-escaped-request/test.config.js
+++ b/test/configCases/library/module-reexport-escaped-request/test.config.js
@@ -1,5 +1,17 @@
 "use strict";
 
+const fs = require("fs");
+const path = require("path");
+
+// A raw U+2028/U+2029 ends a string literal outside the ES2019 JSON superset,
+// so both must reach the emitted specifier escaped.
+const ESCAPED_SPECIFIERS = [
+	/import\s*\*\s*as\s+\S+\s*from\s*"separator\\u2028module"/,
+	/import\s*\*\s*as\s+\S+\s*from\s*"paragraph\\u2029module"/,
+	/export\s*\*\s*from\s*"separator\\u2028module"/,
+	/export\s*\*\s*from\s*"paragraph\\u2029module"/
+];
+
 module.exports = {
 	/**
 	 * @param {number} index configuration index
@@ -15,5 +27,22 @@ module.exports = {
 		"separator\u2028module": { separator: 4 },
 		"paragraph\u2029module": { paragraph: 5 },
 		"plain-module": { plain: 6 }
+	},
+	/**
+	 * @param {import("../../../../").Configuration | import("../../../../").Configuration[]} options webpack options
+	 * @returns {void}
+	 */
+	afterExecute(options) {
+		const configs = Array.isArray(options) ? options : [options];
+		for (const [index, config] of configs.entries()) {
+			const output = /** @type {EXPECTED_ANY} */ (config.output);
+			const source = fs.readFileSync(
+				path.join(output.path, `library${index}.mjs`),
+				"utf8"
+			);
+			for (const specifier of ESCAPED_SPECIFIERS) {
+				expect(source).toMatch(specifier);
+			}
+		}
 	}
 };

--- a/test/configCases/library/module-reexport-escaped-request/test.config.js
+++ b/test/configCases/library/module-reexport-escaped-request/test.config.js
@@ -12,6 +12,8 @@ module.exports = {
 		'quoted"module': { quoted: 1 },
 		"backslash\\module": { backslash: 2 },
 		"line\nmodule": { newline: 3 },
-		"plain-module": { plain: 4 }
+		"separator\u2028module": { separator: 4 },
+		"paragraph\u2029module": { paragraph: 5 },
+		"plain-module": { plain: 6 }
 	}
 };

--- a/test/configCases/library/module-reexport-escaped-request/test.config.js
+++ b/test/configCases/library/module-reexport-escaped-request/test.config.js
@@ -1,0 +1,17 @@
+"use strict";
+
+module.exports = {
+	/**
+	 * @param {number} index configuration index
+	 * @returns {string} emitted test bundle
+	 */
+	findBundle(index) {
+		return `main${index}.mjs`;
+	},
+	modules: {
+		'quoted"module': { quoted: 1 },
+		"backslash\\module": { backslash: 2 },
+		"line\nmodule": { newline: 3 },
+		"plain-module": { plain: 4 }
+	}
+};

--- a/test/configCases/library/module-reexport-escaped-request/webpack.config.js
+++ b/test/configCases/library/module-reexport-escaped-request/webpack.config.js
@@ -19,6 +19,8 @@ module.exports = [
 		'quoted"module',
 		"backslash\\module",
 		"line\nmodule",
+		"separator\u2028module",
+		"paragraph\u2029module",
 		"plain-module"
 	],
 	optimization: { minimize }

--- a/test/configCases/library/module-reexport-escaped-request/webpack.config.js
+++ b/test/configCases/library/module-reexport-escaped-request/webpack.config.js
@@ -1,0 +1,25 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [
+	{ type: "module", minimize: false },
+	{ type: "module", minimize: true },
+	{ type: "modern-module", minimize: false },
+	{ type: "modern-module", minimize: true }
+].map(({ type, minimize }, index) => ({
+	mode: minimize ? "production" : "development",
+	entry: {
+		main: "./index.js",
+		library: { import: "./library.js", library: { type } }
+	},
+	output: { module: true, filename: `[name]${index}.mjs` },
+	externalsType: "module",
+	externals: [
+		{ "./library.mjs": `./library${index}.mjs` },
+		'quoted"module',
+		"backslash\\module",
+		"line\nmodule",
+		"plain-module"
+	],
+	optimization: { minimize }
+}));


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

ESM library star reexports interpolate external requests without escaping, so a request containing a double quote produces invalid JavaScript and fails minification. Serialize the request with `JSON.stringify` to preserve quotes, backslashes and newlines in the emitted module specifier.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `test/configCases/library/module-reexport-escaped-request/` covers escaped requests and a plain request with both module library types, with and without minification; the regression fails before the fix. The 32 selected reexport checks passed across normal and persistent-cache suites, and all 14 checks for the final regression configuration passed on rerun. Formatting, spelling, comment checks and the new configuration's type check passed; ESLint failed while loading the repository configuration (`Expected an object but received undefined`).

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a; a patch changeset is included.

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Codex was used to reproduce the bug, implement the fix, add regression tests, run validation, and draft this description.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed native ESM imports and star re-exports so module requests containing quotes, backslashes, line breaks, or Unicode line and paragraph separators are preserved correctly.
  * Ensured exported values remain available across supported module library configurations and optimization settings.
  * Improved reliability when generating bundles with external module requests containing special characters.

* **Tests**
  * Added coverage for special-character module requests, including Unicode separators, and verified their generated imports, re-exports, and values across supported configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->